### PR TITLE
Allow a Font Awesome Icon to be Set for Quick Links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /dist
 /node_modules
 .env
+/.vs

--- a/public/index.html
+++ b/public/index.html
@@ -1,14 +1,18 @@
 <!doctype html>
 
 <html lang="en">
-  <head>
+<head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
     <meta name="theme-color" content="#3498db">
     <link rel="manifest" href="/pwa.json">
     <link rel="shortcut icon" href="/icons/128.png">
+    <script defer src="https://use.fontawesome.com/releases/v5.0.9/js/all.js" integrity="sha384-8iPTk2s/jMVj81dnzb/iFR2sdA7u06vHJyyLlAd4snFpCl/SnyUjRrbdJsw1pGIl" crossorigin="anonymous"></script>
+    <script>
+        FontAwesomeConfig = { autoReplaceSvg: 'nest' }
+    </script>
     <title> </title>
-  </head>
+</head>
   <body>
     <noscript>
       You need to enable JavaScript to run this app.

--- a/src/plugins/widgets/links/LinkDisplay.tsx
+++ b/src/plugins/widgets/links/LinkDisplay.tsx
@@ -28,17 +28,37 @@ const messages = defineMessages({
   },
 });
 
-const LinkDisplay: React.StatelessComponent<Props & InjectedIntlProps> = (props) => (
-  <a
-    href={props.url}
-    rel="noopener noreferrer"
-    title={props.number < 10
-      ? props.intl.formatMessage(messages.shortcutHint, { number: props.number })
-      : props.intl.formatMessage(messages.standardHint)
+const LinkDisplay: React.StatelessComponent<Props & InjectedIntlProps> = (props) => {
+    let link = [];
+
+    if (props.faIcon) {
+        link.push(<i className={props.faIcon} />);
     }
-  >
-    {props.name || displayUrl(props.url)}
-  </a>
-);
+
+    if (props.name) {
+        if (link.length === 1) {
+            link.push(' ');
+        }
+
+        link.push(props.name);
+    }
+
+    if (link.length === 0) {
+        link.push(displayUrl(props.url));
+    }
+
+    return (
+        <a
+            href={props.url}
+            rel="noopener noreferrer"
+            title={props.number < 10
+                ? props.intl.formatMessage(messages.shortcutHint, { number: props.number })
+                : props.intl.formatMessage(messages.standardHint)
+            }
+        >
+            {link}
+        </a>
+    )
+};
 
 export default injectIntl(LinkDisplay);

--- a/src/plugins/widgets/links/LinkInput.tsx
+++ b/src/plugins/widgets/links/LinkInput.tsx
@@ -42,7 +42,16 @@ const LinkInput: React.StatelessComponent<Props> = (props) => (
         value={props.name}
         onChange={event => props.onChange({ name: event.target.value })}
       />
-    </label>
+        </label>
+
+        <label>
+            Font Awesome Icon <span className="text--grey">(optional)</span>
+            <input
+                type="text"
+                value={props.faIcon}
+                onChange={event => props.onChange({ faIcon: event.target.value })}
+            />
+        </label>
 
     <hr />
   </div>

--- a/src/plugins/widgets/links/interfaces.ts
+++ b/src/plugins/widgets/links/interfaces.ts
@@ -1,5 +1,6 @@
 export interface Link {
   name?: string;
+  faIcon?: string;
   url: string;
 }
 


### PR DESCRIPTION
This is a PR to resolve feature request #36.

## Additions
The Link settings has an additional optional field call _Font Awesome Icon_. This field allows the user to specify the Font Awesome icon they wish to use.
![image](https://user-images.githubusercontent.com/23285467/38568350-0a74f692-3cae-11e8-9cb2-4d0748f9ddfe.png)

## Behavior
When only the _URL_, or when the _URL_ and _Name_ are specified, the application acts as it did before. 

When the _URL_ and _Font Awesome Icon_ are specified, the Font Awesome icon is displayed.
![image](https://user-images.githubusercontent.com/23285467/38568686-dfa9aeb6-3cae-11e8-8016-006c34fcf7e3.png)

When all three are specified, the Font Awesome icon is displayed to the left of the name.
![image](https://user-images.githubusercontent.com/23285467/38568734-0253b286-3caf-11e8-903d-7df8e54e06a6.png)
