### PR TITLE
Add JavaScript Widget

### DIFF
--- a/src/plugins/widgets/js/Js.tsx
+++ b/src/plugins/widgets/js/Js.tsx
@@ -1,0 +1,44 @@
+import * as React from 'react';
+
+interface Props {
+  input?: string;
+}
+
+class Js extends React.PureComponent<Props> {
+  componentDidMount() {
+    this.attach();
+  }
+
+  componentDidUpdate() {
+    this.detach();
+    this.attach();
+  }
+
+  componentWillUnmount() {
+    this.detach();
+  }
+
+  render() {
+    return null;
+  }
+
+  private detach() {
+    const head = document.head as HTMLElement;
+    var script = document.getElementById('CustomJs') as HTMLElement;
+
+    head.removeChild(script);
+  }
+
+  private attach() {
+    const head = document.head as HTMLElement;
+    var script = document.createElement('script');
+
+    script.id = 'CustomJs';
+    script.type = 'text/javascript';
+    script.appendChild(document.createTextNode(this.props.input || ''));
+
+    head.appendChild(script);
+  }
+}
+
+export default Js;

--- a/src/plugins/widgets/js/JsSettings.tsx
+++ b/src/plugins/widgets/js/JsSettings.tsx
@@ -1,0 +1,30 @@
+import * as React from 'react';
+import { Settings } from '../../interfaces';
+
+interface Props {
+  input?: string;
+  onChange: (settings: Settings) => void;
+}
+
+const JsSettings: React.StatelessComponent<Props> = ({ input = '', onChange }) => {
+  return (
+    <div className="JsSettings">
+      <label>
+        JavaScript Snippet
+        <textarea
+          rows={3}
+          style={{ fontFamily: 'monospace' }}
+          value={input}
+          onChange={event => onChange({ input: event.target.value })}
+        />
+      </label>
+
+      <p className="info">
+        Warning: this functionality is intended for advanced users. Custom scripts may break at any time.
+        The script will be run once. Event listener will stay registered even after rerunning(editing) the code.
+      </p>
+    </div>
+  );
+};
+
+export default JsSettings;

--- a/src/plugins/widgets/js/index.ts
+++ b/src/plugins/widgets/js/index.ts
@@ -1,0 +1,2 @@
+export { default as Js } from './Js';
+export { default as JsSettings } from './JsSettings';

--- a/src/plugins/widgets/register.ts
+++ b/src/plugins/widgets/register.ts
@@ -4,6 +4,7 @@ import { registerPlugin } from '../registry';
 import { Css, CssSettings } from './css';
 import { Font, FontSettings } from './font';
 import { Greeting, GreetingSettings } from './greeting';
+import { Js, JsSettings } from './js';
 import { Links, LinksSettings } from './links';
 import { Message, MessageSettings } from './message';
 import { LiteratureClock, LiteratureClockSettings } from './literature-clock';
@@ -35,6 +36,14 @@ registerPlugin({
   title: 'Greeting',
   Dashboard: Greeting,
   Settings: GreetingSettings,
+});
+
+registerPlugin({
+  key: 'core/widgets/js',
+  type: Type.WIDGET,
+  title: 'Custom JS',
+  Dashboard: Js,
+  Settings: JsSettings,
 });
 
 registerPlugin({


### PR DESCRIPTION
I added a new widget for running a bit of JavaScript when opening a new tab. I took the CSS widget as a template.

Due to limitations in the WebExtentions API you can not inject JavaScript into about:newtab. This plugin there for provides a workaround for just that.

The entered JavaScript is run in a non privileged context i.e. can not call add-on API's.

If an event listener is added in the code, it can not really be removed when the code is updated and will be rerun. I suspect that this is not really a problem because this only happens when you edit the code wich will be only a fraction of the time this plugin will be used. To workaround this you can always reload the tab.

I mention this together with a warning like in the CSS plugin under the input box.