### PR TITLE
Attempt to fix #78 by adding image load check

### DIFF
--- a/src/plugins/backgrounds/unsplash/Unsplash.tsx
+++ b/src/plugins/backgrounds/unsplash/Unsplash.tsx
@@ -121,6 +121,12 @@ class Unsplash extends React.PureComponent<Props, State> {
     this.props.updateLocal({ current: {
       ...image, timestamp,
     }});
+    
+    let img = new Image();
+    img.onerror = () => {
+        this.refresh(this.props);
+    };
+    img.src = src;
   }
 
   /**


### PR DESCRIPTION
I tried to add a simple image load check, so when "ERR_FILE_NOT_FOUND" happens then new image will be loaded from Unsplash.

Basically we just check if we are able to load the image with generated url at https://github.com/joelshepherd/tabliss/blob/44f10618552657f4843db861eb2c9f59b9c61912/src/plugins/backgrounds/unsplash/Unsplash.tsx#L115
and if not, then we get new image from Unsplash.

Probably there is a better way to do it: to use already loaded "next" image etc.