### PR TITLE
Fix CSP problems with JS widget

### DIFF
--- a/src/app/settings/Settings.sass
+++ b/src/app/settings/Settings.sass
@@ -36,7 +36,7 @@
         &:last-child
             margin-bottom: 0
 
-    label + .info
+    label ~ .info
         font-size: 0.9em
         margin-top: -0.75rem
 

--- a/src/data/reducers/dashboard.ts
+++ b/src/data/reducers/dashboard.ts
@@ -18,18 +18,6 @@ const initialState = {
 };
 
 export function dashboard(state: Dashboard = initialState, action: Action): Dashboard {
-  // Quick dirty migration, until I implement them officially
-  if (process.env.BUILD_TARGET !== 'web') {
-    const widgetToRemove = 'widgets/js';
-
-    if (state.widgets.includes(widgetToRemove)) {
-      state = {
-        ...state,
-        widgets: state.widgets.filter(widget => widget !== widgetToRemove),
-      };
-    }
-  }
-
   switch (action.type) {
     case CHANGE_BACKGROUND:
       return {

--- a/src/data/reducers/dashboard.ts
+++ b/src/data/reducers/dashboard.ts
@@ -18,6 +18,18 @@ const initialState = {
 };
 
 export function dashboard(state: Dashboard = initialState, action: Action): Dashboard {
+    // Quick dirty migration, until I implement them officially
+  if (process.env.BUILD_TARGET === 'chrome') {
+    const widgetToRemove = 'widgets/js';
+
+    if (state.widgets.includes(widgetToRemove)) {
+      state = {
+        ...state,
+        widgets: state.widgets.filter(widget => widget !== widgetToRemove),
+      };
+    }
+  }
+
   switch (action.type) {
     case CHANGE_BACKGROUND:
       return {

--- a/src/plugins/widgets/css/CssSettings.tsx
+++ b/src/plugins/widgets/css/CssSettings.tsx
@@ -20,7 +20,7 @@ const CssSettings: React.StatelessComponent<Props> = ({ input = '', onChange }) 
       </label>
 
       <p className="info">
-        Warning: this functionality is intended for advanced users.
+        <b>Warning:</b> this functionality is intended for advanced users.
         Custom styles may break at any time.
       </p>
     </div>

--- a/src/plugins/widgets/js/Js.sass
+++ b/src/plugins/widgets/js/Js.sass
@@ -1,0 +1,4 @@
+.JsSettings
+    .button--primary
+        margin-top: -0.5em
+        margin-bottom: 1.1em

--- a/src/plugins/widgets/js/Js.tsx
+++ b/src/plugins/widgets/js/Js.tsx
@@ -5,7 +5,6 @@ interface Props {
 }
 
 declare const browser: any; // tslint:disable-line no-any
-declare const chrome: any; // tslint:disable-line no-any
 
 class Js extends React.PureComponent<Props> {
   componentDidMount() {
@@ -40,18 +39,13 @@ class Js extends React.PureComponent<Props> {
       if (process.env.BUILD_TARGET === 'web') {
         const script = document.createElement('script');
 
-        script.id = 'CustomJs';
-        script.type = 'text/javascript';
+        script.setAttribute('id', 'CustomJs');
+        script.setAttribute('type', 'text/javascript');
         script.appendChild(document.createTextNode(this.props.input || ''));
 
         document.head.appendChild(script);
       } else if (process.env.BUILD_TARGET === 'firefox') {
         browser.tabs.executeScript({
-          allFrames: false,
-          code: '(function() {' + this.props.input + '})();'
-        });
-      } else if (process.env.BUILD_TARGET === 'chrome') {
-        chrome.tabs.executeScript({
           allFrames: false,
           code: '(function() {' + this.props.input + '})();'
         });

--- a/src/plugins/widgets/js/JsSettings.tsx
+++ b/src/plugins/widgets/js/JsSettings.tsx
@@ -1,31 +1,55 @@
 import * as React from 'react';
 import { Settings } from '../../interfaces';
 
+interface State {
+  input: string;
+}
+
 interface Props {
-  input?: string;
+  input: string;
   onChange: (settings: Settings) => void;
 }
 
-const JsSettings: React.StatelessComponent<Props> = ({ input = '', onChange }) => {
-  return (
-    <div className="JsSettings">
-      <label>
-        JavaScript Snippet
-        <textarea
-          rows={3}
-          style={{ fontFamily: 'monospace' }}
-          value={input}
-          onChange={event => onChange({ input: event.target.value })}
-        />
-      </label>
+class JsSettings extends React.PureComponent<Props, State> {
+  static defaultProps: Partial<Props> = {
+    input: ''
+  };
 
-      <p className="info">
-        Warning: this functionality is intended for advanced users. Custom scripts may break at any time.
-        The snippet will run once after the dashboard has loaded.
-        Be careful of persisting event listeners when editing the snippet.
-      </p>
-    </div>
-  );
-};
+  constructor(props: Props) {
+    super(props);
+    this.state = {
+      input: props.input
+    };
+  }
+
+  render() {
+    return (
+      <div className="JsSettings">
+        <label>
+          JavaScript Snippet
+          <textarea
+            rows={3}
+            style={{ fontFamily: 'monospace' }}
+            value={this.state.input}
+            onChange={event => this.setState({input: event.target.value})}
+          />
+        </label>
+
+        <button
+          className="button--primary"
+          onClick={() => this.props.onChange({input: this.state.input})}>
+          Save & Run
+        </button>
+
+        <p className="info">
+          <b>Warning:</b> this functionality is intended for advanced users.
+          Please make sure you know what you are doing, snippets could lead to security vulnerabilities.
+          The snippet will run once after the dashboard has loaded.
+          Persisting event listeners will not be removed when reruning the snippet.
+        </p>
+      </div>
+    );
+  }
+}
 
 export default JsSettings;

--- a/src/plugins/widgets/js/JsSettings.tsx
+++ b/src/plugins/widgets/js/JsSettings.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { Settings } from '../../interfaces';
+import './Js.sass';
 
 interface State {
   input: string;

--- a/src/plugins/widgets/register.ts
+++ b/src/plugins/widgets/register.ts
@@ -39,13 +39,16 @@ registerPlugin({
   Settings: GreetingSettings,
 });
 
-registerPlugin({
-  key: 'widgets/js',
-  type: Type.WIDGET,
-  title: 'Custom JS',
-  Dashboard: Js,
-  Settings: JsSettings,
-});
+// Not available on chrome due to extension's CSP
+if (process.env.BUILD_TARGET !== 'chrome') {
+  registerPlugin({
+    key: 'widgets/js',
+    type: Type.WIDGET,
+    title: 'Custom JS',
+    Dashboard: Js,
+    Settings: JsSettings,
+  });
+}
 
 registerPlugin({
   key: 'core/widgets/links',

--- a/src/plugins/widgets/register.ts
+++ b/src/plugins/widgets/register.ts
@@ -39,16 +39,13 @@ registerPlugin({
   Settings: GreetingSettings,
 });
 
-// Only available on the web version due to extension's CSP
-if (process.env.BUILD_TARGET === 'web') {
-  registerPlugin({
-    key: 'widgets/js',
-    type: Type.WIDGET,
-    title: 'Custom JS',
-    Dashboard: Js,
-    Settings: JsSettings,
-  });
-}
+registerPlugin({
+  key: 'widgets/js',
+  type: Type.WIDGET,
+  title: 'Custom JS',
+  Dashboard: Js,
+  Settings: JsSettings,
+});
 
 registerPlugin({
   key: 'core/widgets/links',


### PR DESCRIPTION
Updated the JS widget to fix the problems mentioned in issue #90. The web version as well as the Firefox add-on now work again.

Chrome on the other hand does not. I have tried lots of things but came to the conclusion that it is not possible to dynamically run custom scripts.
It appears as if the CSP rules for inlining can't be relaxed to a point where a script can actually influence the current new tab page. Adding unsafe-inline or unsafe-eval to the CSP rules does nothing. If I add the hash of a specific script it would work as expected, but since the scripts are user supplied this is not an option either.
This is very weird as I could not find any documentation for this behavior.

The [tabs.executeScript](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/tabs/executeScript) works in Firefox but not in Chrome. It seems like it does not have the permission to inject into the new tab.

In chrome you can [sandbox](https://developer.chrome.com/extensions/manifest/sandbox) certain files. This could be used to execute scripts but obviously it does not have access to the DOM of the new tab page. In theory you could expose an API to the script but I don't think that is worth the effort.

Tested on:
Firefox 66.0.3 (64-bit), Arch Linux
Chromium 74.0.3729.131 (64-bit), Arch Linux