### PR TITLE
Feature request: Add photo download link

### DIFF
--- a/src/plugins/backgrounds/unsplash/UnsplashCredit.tsx
+++ b/src/plugins/backgrounds/unsplash/UnsplashCredit.tsx
@@ -24,6 +24,16 @@ const UnsplashCredit: React.StatelessComponent<Props> = (props) => (
         defaultMessage="Photo"
       />
     </a>
+    <a
+      href={props.image.image_link + '/download?force=true'}
+      rel="noopener noreferrer"
+    >
+      <FormattedMessage
+        id="plugins.unsplash.photoDownloadLink"
+        description="Photo download link text"
+        defaultMessage=" (↓)"
+      />
+    </a>
     {' / '}
     <a
       href={props.image.user_link + UNSPLASH_UTM}


### PR DESCRIPTION
Hello! Thanks for the beautiful extension!

I'd love to have direct 'download' button somewhere at extension screen, so I could get the photo directly, without hoping to Unsplash. Could you review the pull and add the link, if it doesn't get across your agreements with Unsplash.