### PR TITLE
Remove extra space in sv.json

### DIFF
--- a/src/locales/lang/sv.json
+++ b/src/locales/lang/sv.json
@@ -11,6 +11,6 @@
   "plugins.links.standardHint": "Klicka för att besöka",
   "plugins.search.placeholder": "Skriv för att söka",
   "plugins.unsplash.photoLink": "Foto",
-  "settings.translationCredits": "Swedish translation by Vecopotryx ",
+  "settings.translationCredits": "Swedish translation by Vecopotryx",
   "widgets": "Widgets"
 }


### PR DESCRIPTION
I accidentally added a space at the end in the translation credit. I was worried that it would cause issues with text formatting so I have removed it. Sorry for the confusion, I'm still learning :)