### PR TITLE
Bring back the font weight selector

### DIFF
--- a/src/views/dashboard/Widgets.sass
+++ b/src/views/dashboard/Widgets.sass
@@ -13,5 +13,6 @@
             pointer-events: all
 
     h1, h2, h3, h4
+        font-weight: inherit
         line-height: 1
         margin: 0

--- a/src/views/settings/Widget.tsx
+++ b/src/views/settings/Widget.tsx
@@ -85,17 +85,17 @@ const Widget: FC<Props> = ({ plugin, onMoveDown, onMoveUp, onRemove }) => {
                 <input
                   type="text"
                   value={plugin.display.fontFamily}
-                  onChange={event =>
+                  onChange={(event) =>
                     boundSetDisplay({ fontFamily: event.target.value })
                   }
                 />
               </label>
 
-              {/* <label>
+              <label>
                 Font Weight
                 <select
                   value={plugin.display.fontWeight}
-                  onChange={event =>
+                  onChange={(event) =>
                     boundSetDisplay({ fontWeight: Number(event.target.value) })
                   }
                 >
@@ -107,14 +107,14 @@ const Widget: FC<Props> = ({ plugin, onMoveDown, onMoveUp, onRemove }) => {
                   <option value={700}>Bold</option>
                   <option value={900}>Black</option>
                 </select>
-              </label> */}
+              </label>
 
               <label>
                 Colour
                 <input
                   type="color"
                   value={plugin.display.colour}
-                  onChange={event =>
+                  onChange={(event) =>
                     boundSetDisplay({ colour: event.target.value })
                   }
                 />


### PR DESCRIPTION
There was a commented out font weight selector. I have bought it back, along with settings all the headings inside of the dash board to `font-weight: inherit`. This should allow the font weight to be overridden. 
Fixes: #210