### PR TITLE
Better typography for quotes

### DIFF
--- a/src/plugins/widgets/quote/api.ts
+++ b/src/plugins/widgets/quote/api.ts
@@ -79,8 +79,12 @@ export async function getQuote(
   const threeDots = new RegExp(/\.{3,}/, 'g');
   quote.quote = quote.quote.replace(threeDots, '…');
 
+  // We replace all series of spaces by a single one.
+  const spaces = new RegExp(/\s{2,}/, 'g');
+  quote.quote = quote.quote.replace(spaces, ' ');
+
   // We replace all dashes between whitespace characters by a proper em dash (—).
-  const dash = new RegExp(/\s+-\s+/, 'g');
+  const dash = new RegExp(/\s-\s/, 'g');
   quote.quote = quote.quote.replace(dash, '—');
 
   // We add a period at the end of the quote if need be.

--- a/src/plugins/widgets/quote/api.ts
+++ b/src/plugins/widgets/quote/api.ts
@@ -62,6 +62,32 @@ export async function getQuote(
 
   loader.pop();
 
+  // We remove whitespaces at the beginning and the end of the quote.
+  quote.quote = quote.quote.trim();
+
+  // We change all straight quotes (' and ") following a non-whitespace character by
+  // a closing curvy quote (’).
+  const singleStraightQuote = new RegExp(/(\S)'|"/, 'g');
+  quote.quote = quote.quote.replace(singleStraightQuote, '$1’');
+
+  // We now change all remaining straight quotes (all following a whitespace
+  // character) by an opening curvy quote (‘).
+  const openingStraightQuote = new RegExp(/(^|\s)'|"/, 'g');
+  quote.quote = quote.quote.replace(openingStraightQuote, '$1‘');
+
+  // We replace all series of three dots or more by a proper ellipsis (…).
+  const threeDots = new RegExp(/\.{3,}/, 'g');
+  quote.quote = quote.quote.replace(threeDots, '…');
+
+  // We replace all dashes between whitespace characters by a proper em dash (—).
+  const dash = new RegExp(/\s+-\s+/, 'g');
+  quote.quote = quote.quote.replace(dash, '—');
+
+  // We add a period at the end of the quote if need be.
+  const closingPunctuation = new RegExp(/[.\?!…’]$/);
+  if (!quote.quote.match(closingPunctuation))
+    quote.quote = quote.quote + '.';
+
   return {
     ...quote,
     timestamp: Date.now(),


### PR DESCRIPTION
### Changes
This intends to improve the typographical correctness of the Quotes widget, by performing various operations in the `getQuote` function:

- Removing whitespace characters at the beginning and the end of the quote.
- Replacing all non conventional ellipsis by a proper one (…).
- Replacing all improper hyphens by a proper em dash (—).
- Replacing all series of spaces by a single one.
- Replacing all straight quotes (' and ") by curvy ones (‘ and ’), choosing one or the other depending on the previous characters.
- Adding a closing period at the end of the quote if need be.

This is in keeping with proper typographical rules, as one can find in [the key rules](https://practicaltypography.com/summary-of-key-rules.html) from _Butterick’s Practical Typography_ book.

This makes extensive use of regular expressions, hence the numerous comments in the code.