### PR TITLE
Add RSS Feed widget for quotes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10613,6 +10613,22 @@
         "inherits": "^2.0.1"
       }
     },
+    "rss-parser": {
+      "version": "3.7.6",
+      "resolved": "https://registry.npmjs.org/rss-parser/-/rss-parser-3.7.6.tgz",
+      "integrity": "sha512-wWWh3/pPLAPgWyfkCC9jB83jSBenU6VPMymfXiysi8wJxaN7KNkW4vU3Jm8jQxExAribFvXREy+RtaL3XQubeA==",
+      "requires": {
+        "entities": "^1.1.1",
+        "xml2js": "^0.4.19"
+      },
+      "dependencies": {
+        "entities": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
+          "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
+        }
+      }
+    },
     "rsvp": {
       "version": "4.8.5",
       "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
@@ -10856,6 +10872,11 @@
           "dev": true
         }
       }
+    },
+    "sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
     "saxes": {
       "version": "3.1.11",
@@ -14031,6 +14052,20 @@
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
       "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
       "dev": true
+    },
+    "xml2js": {
+      "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
+      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
+      "requires": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      }
+    },
+    "xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
     },
     "xmlchars": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "redux": "^4.0.5",
     "redux-persist": "^6.0.0",
     "redux-persist-webextension-storage": "^1.0.2",
+    "rss-parser": "^3.7.6",
     "tlds": "^1.207.0",
     "uuid": "^7.0.3"
   },

--- a/src/plugins/widgets/index.ts
+++ b/src/plugins/widgets/index.ts
@@ -7,6 +7,7 @@ import message from './message';
 import nba from './nba';
 import quote from './quote';
 import search from './search';
+import rss from './rss';
 import time from './time';
 import todo from './todo';
 import weather from './weather';
@@ -20,6 +21,7 @@ export const widgetConfigs = [
   nba,
   quote,
   search,
+  rss,
   time,
   todo,
   weather,

--- a/src/plugins/widgets/rss/Rss.sass
+++ b/src/plugins/widgets/rss/Rss.sass
@@ -1,0 +1,2 @@
+h4.Quote
+    line-height: 1.25 !important

--- a/src/plugins/widgets/rss/Rss.tsx
+++ b/src/plugins/widgets/rss/Rss.tsx
@@ -1,0 +1,36 @@
+import React, { FC } from 'react';
+
+import { useCachedEffect } from '../../../hooks';
+import { getQuote } from './api';
+import { Props, defaultData } from './types';
+import './Rss.sass';
+
+const EXPIRE_IN = 60 * 60 * 1000; // 1 hour
+
+const Quote: FC<Props> = ({ cache, data = defaultData, setCache, loader }) => {
+  useCachedEffect(
+    () => {
+      getQuote(loader, data.url).then(setCache);
+    },
+    cache ? cache.timestamp + EXPIRE_IN : 0,
+    [data.url],
+  );
+
+  if (!cache) {
+    return null;
+  }
+
+  return (
+    <h4 className="Quote">
+      “{cache.quote}”
+      {cache.author && (
+        <sub>
+          <br />
+          &mdash; {cache.author}
+        </sub>
+      )}
+    </h4>
+  );
+};
+
+export default Quote;

--- a/src/plugins/widgets/rss/RssSettings.tsx
+++ b/src/plugins/widgets/rss/RssSettings.tsx
@@ -1,0 +1,18 @@
+import React, { FC } from 'react';
+
+import { Props, defaultData } from './types';
+
+const QuoteSettings: FC<Props> = ({ data = defaultData, setData }) => (
+  <div className="RssSettings">
+    <label>
+      URL
+      <input
+        type="url"
+        value={data.url}
+        onChange={event => setData({ url: event.target.value })}
+      />
+    </label>
+  </div>
+);
+
+export default QuoteSettings;

--- a/src/plugins/widgets/rss/api.ts
+++ b/src/plugins/widgets/rss/api.ts
@@ -1,0 +1,92 @@
+import Parser from 'rss-parser';
+
+import { API } from '../../types';
+import { Quote } from './types';
+
+async function getQuoteFromFeed(url: string) {
+  try {
+    const parser = new Parser();
+    const feed = await parser.parseURL(url);
+    if (!(feed && feed.items && feed.items[0])) {
+      return {
+        quote: 'Unable to parse RSS feed',
+      };
+    }
+    const item = feed.items[0];
+    const singleInfo = item.title || item.content;
+    if (item.title && item.content) {
+      return {
+        author: item.title,
+        quote: item.content,
+      };
+    } else if (singleInfo) {
+      return {
+        quote: singleInfo,
+      }
+    }
+    return {
+      quote: 'Empty RSS feed item',
+    };
+  } catch (err) {
+    return {
+      quote: 'Unable to get RSS feed',
+    };
+  }
+}
+
+export async function getQuote(
+  loader: API['loader'],
+  url: string,
+): Promise<Quote> {
+  loader.push();
+
+  const data = await getQuoteFromFeed(url);
+
+  loader.pop();
+
+  const quote = cleanQuote(data.quote);
+
+  return {
+    ...data,
+    quote,
+    timestamp: Date.now(),
+  };
+}
+
+function cleanQuote(quote: string) {
+  // We remove whitespaces at the beginning and the end of the quote.
+  quote = quote.trim();
+
+  // We remove enclosing quotes if they enclose the whole quote
+  // Prevents doubled quotion marks
+  const enclosingQuotes = new RegExp(/^['"]?(.*)['"]?$/, 'g');
+  quote = quote.replace(enclosingQuotes, '$1');
+
+  // We change all straight quotes (' and ") following a non-whitespace character by
+  // a closing curvy quote (’).
+  const singleStraightQuote = new RegExp(/(\S)'|"/, 'g');
+  quote = quote.replace(singleStraightQuote, '$1’');
+
+  // We now change all remaining straight quotes (all following a whitespace
+  // character) by an opening curvy quote (‘).
+  const openingStraightQuote = new RegExp(/(^|\s)'|"/, 'g');
+  quote = quote.replace(openingStraightQuote, '$1‘');
+
+  // We replace all series of three dots or more by a proper ellipsis (…).
+  const threeDots = new RegExp(/\.{3,}/, 'g');
+  quote = quote.replace(threeDots, '…');
+
+  // We replace all series of spaces by a single one.
+  const spaces = new RegExp(/\s{2,}/, 'g');
+  quote = quote.replace(spaces, ' ');
+
+  // We replace all dashes between whitespace characters by a proper em dash (—).
+  const dash = new RegExp(/\s-\s/, 'g');
+  quote = quote.replace(dash, '—');
+
+  // We add a period at the end of the quote if need be.
+  const closingPunctuation = new RegExp(/[.\?!…’]$/);
+  if (!quote.match(closingPunctuation)) quote = quote + '.';
+
+  return quote;
+}

--- a/src/plugins/widgets/rss/index.ts
+++ b/src/plugins/widgets/rss/index.ts
@@ -1,0 +1,13 @@
+import { Config } from '../../types';
+import Quote from './Rss';
+import QuoteSettings from './RssSettings';
+
+const config: Config = {
+  key: 'widget/rss',
+  name: 'RSS Feed',
+  description: "Be inspired by your own choosen feed.",
+  dashboardComponent: Quote,
+  settingsComponent: QuoteSettings,
+};
+
+export default config;

--- a/src/plugins/widgets/rss/types.ts
+++ b/src/plugins/widgets/rss/types.ts
@@ -1,0 +1,17 @@
+import { API } from '../../types';
+
+export type Quote = {
+  author?: string;
+  quote: string;
+  timestamp: number;
+};
+
+type Data = {
+  url: string;
+};
+
+type Cache = Quote;
+
+export type Props = API<Data, Cache>;
+
+export const defaultData: Data = { url: '' };


### PR DESCRIPTION
Implements #195

However I cannot test it currently because of a CORS issue with the example feed url. I tested it with running Tabliss as local web server. The package I use to parse the feed [suggests](https://www.npmjs.com/package/rss-parser#web) that you use a proxy for this. I can implement a feature like that but I hope this is not to be required. Does anyone know if this issue still applies to pages given by addons in Firefox / Chrome?