### PR TITLE
Fix issues with react-intl and time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Alignment of multi-column quick links when they are narrower than other widgets in their slot
 - Search box now properly respects light mode
+- Midnight showing as "24:00" in Chrome when using 24-hour time - thanks @trickypr!
 
 ## [2.0.3] - 2020-04-15
 

--- a/src/plugins/widgets/time/Digital.tsx
+++ b/src/plugins/widgets/time/Digital.tsx
@@ -9,10 +9,10 @@ type Props = {
   time: Date;
 };
 
-const Digital: FC<Props> = ({ time, hour12, showMinutes, showSeconds }) => (
+const Digital: FC<Props> = (props) => (
   <div className="Time Digital">
     <h1>
-      <IntlTime time={time} hour12={hour12} showMinutes={showMinutes} showSeconds={showSeconds} />
+      <IntlTime {...props} />
     </h1>
   </div>
 );

--- a/src/plugins/widgets/time/Digital.tsx
+++ b/src/plugins/widgets/time/Digital.tsx
@@ -1,5 +1,6 @@
 import React, { FC } from 'react';
-import { FormattedTime } from 'react-intl';
+
+import IntlTime from './IntlTime'
 
 type Props = {
   hour12: boolean;
@@ -11,13 +12,7 @@ type Props = {
 const Digital: FC<Props> = ({ time, hour12, showMinutes, showSeconds }) => (
   <div className="Time Digital">
     <h1>
-      <FormattedTime
-        value={time}
-        hour12={hour12}
-        hour="numeric"
-        minute={showMinutes ? 'numeric' : undefined}
-        second={showSeconds ? 'numeric' : undefined}
-      />
+      <IntlTime time={time} hour12={hour12} showMinutes={showMinutes} showSeconds={showSeconds} />
     </h1>
   </div>
 );

--- a/src/plugins/widgets/time/IntlTime.tsx
+++ b/src/plugins/widgets/time/IntlTime.tsx
@@ -1,0 +1,51 @@
+import React, { FC } from "react";
+
+import { useSelector } from '../../../store';
+
+type Props = {
+  hour12: boolean;
+  showMinutes: boolean;
+  showSeconds: boolean;
+  time: Date;
+};
+
+
+/**
+ * A react wrapper around `Intl.DateTimeFromat().format()`
+ * 
+ * Todo: Remove this component when react-intl adds the hourCycle option to their component
+ * 
+ * 
+ * Intl Issue information: https://github.com/formatjs/react-intl/issues/1577
+ * Code based on: https://github.com/mattermost/mattermost-webapp/pull/5138
+ * Tabliss issue: https://github.com/joelshepherd/tabliss/issues/231
+ */
+const IntlTime: FC<Props> = ({ hour12, showMinutes, showSeconds, time }) => {
+  const locale = useSelector(state => state.data.locale);
+
+  // React types for .format() do not include hourCycle
+  const options: {
+    hour?: string;
+    minute?: string;
+    second?: string;
+    hour12?: boolean;
+    timeZone?: string;
+    hourCycle?: string;
+  } = {
+    hour12,
+    hour: 'numeric',
+    hourCycle: hour12 ? 'h12' : 'h23',
+    minute: showMinutes ? 'numeric' : undefined,
+    second: showSeconds ? 'numeric' : undefined
+  }
+
+  const formatedTime = Intl.DateTimeFormat(locale, options).format(time)
+
+  return (
+    <>
+      {formatedTime}
+    </>
+  )
+}
+
+export default IntlTime


### PR DESCRIPTION
**tl;dr** 
Chrom(ium) did a thing. React-intl didn't implement the thing I need to do to fix the thing.

**Detailed description**
Somewhere around chrome 80 `hourCycle` was added as a property in the config for `Intl.DateTimeFromat()`. `hourCycle` defaults to `h24` that goes from `01:XX` - `24:XX` rather than `h23` that goes from `00:XX` - `23:XX`. React-intl doesn't [appear to have added that change to their library as of yet](https://github.com/formatjs/react-intl/issues/1577). This commit has a custom implementation of `Intl.DateTimeFromat().format()` to bypass this issue. This issue should also prevent breakages in the future as other browsers at this feature. 

At some point `react-intl` will allow this to be cofigured in their library and this pull request can be reverted, with the addition of the `hourCycle` property to the `FormattedTime` property. 

Fixes #231 