### PR TITLE
Ignore system keystrokes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Alignment of multi-column quick links when they are narrower than other widgets in their slot
 - Search box now properly respects light mode
 - Midnight showing as "24:00" in Chrome when using 24-hour time - thanks @trickypr!
+- Ignore keyboard shortcuts including meta, control or alt keys
 
 ## [2.0.3] - 2020-04-15
 

--- a/src/hooks/useKeyPress.ts
+++ b/src/hooks/useKeyPress.ts
@@ -17,7 +17,8 @@ export function useKeyPress(
   const handler = (event: KeyboardEvent) => {
     if (
       detectKeys.includes(event.key) &&
-      !(ignoreInputEvents && isInputEvent(event))
+      !(ignoreInputEvents && isInputEvent(event)) &&
+      !(event.ctrlKey || event.metaKey || event.altKey)
     ) {
       callback(event);
     }


### PR DESCRIPTION
Prior to this commit, tabliss responded to keystrokes meant for the browser or system. One example of this is if you used alt (or meta on mac) + a number to switch tabs, you would trigger tabliss to open a quick link at the same time. This pull request stops tabliss from registering key strokes when the meta, control or alt keys are pressed. 

Fixes #235.