### PR TITLE
Add toggle for day period

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Improved typography in quotes - thanks @apollisa
 - Simplifying add todo interface
+- Toggle AM / PM for 24 hour time
 
 ## Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Improved typography in quotes - thanks @apollisa
 - Simplifying add todo interface
-- Toggle AM / PM for 24 hour time
+- Toggle AM / PM for 12 hour time
 
 ## Fixed
 

--- a/src/plugins/widgets/time/Digital.tsx
+++ b/src/plugins/widgets/time/Digital.tsx
@@ -1,11 +1,12 @@
 import React, { FC } from 'react';
 
-import IntlTime from './IntlTime'
+import IntlTime from './IntlTime';
 
 type Props = {
   hour12: boolean;
   showMinutes: boolean;
   showSeconds: boolean;
+  showDayPeriod: boolean;
   time: Date;
 };
 

--- a/src/plugins/widgets/time/IntlTime.tsx
+++ b/src/plugins/widgets/time/IntlTime.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from "react";
+import React, { FC } from 'react';
 
 import { useSelector } from '../../../store';
 
@@ -6,24 +6,30 @@ type Props = {
   hour12: boolean;
   showMinutes: boolean;
   showSeconds: boolean;
+  showDayPeriod?: boolean;
   time: Date;
 };
 
-
 /**
  * A react wrapper around `Intl.DateTimeFromat().format()`
- * 
+ *
  * Todo: Remove this component when react-intl adds the hourCycle option to their component
- * 
- * 
+ *
+ *
  * Intl Issue information: https://github.com/formatjs/react-intl/issues/1577
  * Code based on: https://github.com/mattermost/mattermost-webapp/pull/5138
  * Tabliss issue: https://github.com/joelshepherd/tabliss/issues/231
  */
-const IntlTime: FC<Props> = ({ hour12, showMinutes, showSeconds, time }) => {
-  const locale = useSelector(state => state.data.locale);
+const IntlTime: FC<Props> = ({
+  hour12,
+  showMinutes,
+  showSeconds,
+  showDayPeriod = true,
+  time,
+}) => {
+  const locale = useSelector((state) => state.data.locale);
 
-  // React types for .format() do not include hourCycle
+  // Typescript types for Intl.DateTimeFormat do not include hourCycle
   const options: {
     hour?: string;
     minute?: string;
@@ -36,16 +42,29 @@ const IntlTime: FC<Props> = ({ hour12, showMinutes, showSeconds, time }) => {
     hour: 'numeric',
     hourCycle: hour12 ? 'h12' : 'h23',
     minute: showMinutes ? 'numeric' : undefined,
-    second: showSeconds ? 'numeric' : undefined
+    second: showSeconds ? 'numeric' : undefined,
+  };
+
+  // Time formatter config
+  const formater = Intl.DateTimeFormat(locale, options);
+
+  let formatedTime: String;
+
+  if (showDayPeriod) {
+    // Return normal time if showing timePeriod
+    formatedTime = formater.format(time);
+  } else {
+    // Remove timePeriod from string
+    // Returns the date broken down into parts
+    const dateParts = formater.formatToParts(time);
+
+    formatedTime = dateParts
+      .filter((part) => part.type !== 'dayPeriod') // Removes day period from the array
+      .map((part) => part.value) // Converts array of objects to array of strings
+      .join('');
   }
 
-  const formatedTime = Intl.DateTimeFormat(locale, options).format(time)
+  return <>{formatedTime}</>;
+};
 
-  return (
-    <>
-      {formatedTime}
-    </>
-  )
-}
-
-export default IntlTime
+export default IntlTime;

--- a/src/plugins/widgets/time/Time.tsx
+++ b/src/plugins/widgets/time/Time.tsx
@@ -17,6 +17,7 @@ const Time: FC<Props> = ({ data = defaultData }) => {
     showMinutes,
     showSeconds,
     timeZone,
+    showDayPeriod = true,
   } = data;
   let time = useTime(timeZone ? 'absolute' : 'zoned');
 
@@ -38,6 +39,7 @@ const Time: FC<Props> = ({ data = defaultData }) => {
           hour12={hour12}
           showMinutes={showMinutes}
           showSeconds={showSeconds}
+          showDayPeriod={showDayPeriod}
         />
       )}
       {name && <h2>{name}</h2>}

--- a/src/plugins/widgets/time/TimeSettings.tsx
+++ b/src/plugins/widgets/time/TimeSettings.tsx
@@ -75,16 +75,18 @@ const TimeSettings: FC<Props> = ({ data = defaultData, setData }) => (
       Display the date
     </label>
 
-    <label>
-      <input
-        type="checkbox"
-        checked={data.showDayPeriod}
-        onChange={() =>
-          setData({ ...data, showDayPeriod: !data.showDayPeriod })
-        }
-      />{' '}
-      Display AM / PM
-    </label>
+    {data.mode === 'digital' && data.hour12 && (
+      <label>
+        <input
+          type="checkbox"
+          checked={data.showDayPeriod}
+          onChange={() =>
+            setData({ ...data, showDayPeriod: !data.showDayPeriod })
+          }
+        />{' '}
+        Display AM / PM
+      </label>
+    )}
   </div>
 );
 

--- a/src/plugins/widgets/time/TimeSettings.tsx
+++ b/src/plugins/widgets/time/TimeSettings.tsx
@@ -74,6 +74,17 @@ const TimeSettings: FC<Props> = ({ data = defaultData, setData }) => (
       />{' '}
       Display the date
     </label>
+
+    <label>
+      <input
+        type="checkbox"
+        checked={data.showDayPeriod}
+        onChange={() =>
+          setData({ ...data, showDayPeriod: !data.showDayPeriod })
+        }
+      />{' '}
+      Display AM / PM
+    </label>
   </div>
 );
 

--- a/src/plugins/widgets/time/types.ts
+++ b/src/plugins/widgets/time/types.ts
@@ -6,6 +6,7 @@ type Data = {
   showDate: boolean;
   showMinutes: boolean;
   showSeconds: boolean;
+  showDayPeriod?: boolean;
   timeZone?: string;
   name?: string;
 };
@@ -18,4 +19,5 @@ export const defaultData: Data = {
   showDate: false,
   showMinutes: true,
   showSeconds: false,
+  showDayPeriod: true,
 };


### PR DESCRIPTION
This pull request adds a checkbox that allows you to toggle the display of `AM` / `PM`. Possible implementations were discussed in #247. 

Fixes #247.