### PR TITLE
use defaultValue instead of default to keep cursor

### DIFF
--- a/src/plugins/widgets/links/Input.tsx
+++ b/src/plugins/widgets/links/Input.tsx
@@ -45,7 +45,7 @@ const Input: FC<Props> = props => (
       URL
       <input
         type="url"
-        value={props.url}
+        defaultValue={props.url}
         onChange={event => props.onChange({ url: event.target.value })}
       />
     </label>
@@ -54,7 +54,7 @@ const Input: FC<Props> = props => (
       Name <span className="text--grey">(optional)</span>
       <input
         type="text"
-        value={props.name}
+        defaultValue={props.name}
         onChange={event => props.onChange({ name: event.target.value })}
       />
     </label>


### PR DESCRIPTION
When you type into the text field, the cursor position will jump to the end like in [this](https://stackoverflow.com/questions/54745557/how-to-keep-cursor-position-in-a-react-input-element) issue. This MR will apply the proposed solution