### PR TITLE
Add ability to save and restore settings from JSON

### DIFF
--- a/src/views/settings/Settings.tsx
+++ b/src/views/settings/Settings.tsx
@@ -22,7 +22,7 @@ const Settings: FC = () => {
   ]);
   const handleReset = useCallback(() => dispatch(resetStore()), [dispatch]);
   const handleExport = async () => {
-    const data = await dataStorage.getItem('persist:data');
+  const { data } = useSelector((state) => state);
     const jsonData = JSON.stringify(data);
     const url = URL.createObjectURL(new Blob([jsonData], { type: 'octet/stream' }));
     const a = document.createElement('a');

--- a/src/views/settings/Settings.tsx
+++ b/src/views/settings/Settings.tsx
@@ -4,6 +4,8 @@ import { useDispatch } from 'react-redux';
 
 import { useKeyPress } from '../../hooks';
 import { resetStore, toggleSettings } from '../../store/actions';
+import { dataStorage } from '../../store/storage';
+import { DataState } from '../../store/reducers/types';
 import { Icon } from '../shared';
 import Logo from '../shared/Logo';
 import Background from './Background';
@@ -19,6 +21,37 @@ const Settings: FC = () => {
     dispatch,
   ]);
   const handleReset = useCallback(() => dispatch(resetStore()), [dispatch]);
+  const handleExport = async () => {
+    const data = await dataStorage.getItem('persist:data');
+    const jsonData = JSON.stringify(data);
+    const url = URL.createObjectURL(new Blob([jsonData], { type: 'octet/stream' }));
+    const a = document.createElement('a');
+    document.body.appendChild(a);
+    a.style.display = 'none';
+    a.href = url;
+    a.download = 'tabliss.json';
+    a.click();
+    window.URL.revokeObjectURL(url);
+  }
+  const handleImport = () => {
+    const input = document.createElement('input');
+    document.body.appendChild(input);
+    input.type = 'file';
+    input.addEventListener('change', function () {
+      if (this.files) {
+        const file = this.files[0];
+        const reader = new FileReader();
+        reader.addEventListener('load', (event) => {
+          if (event && event.target && event.target.result) {
+            const state: DataState = JSON.parse(event.target.result as string);
+            dispatch(resetStore(state));
+          }
+        });
+        reader.readAsText(file);
+      }
+    });
+    input.click();
+  }
 
   useKeyPress(handleToggleSettings, ['Escape']);
 
@@ -47,6 +80,14 @@ const Settings: FC = () => {
           >
             Love Tabliss? Donate 😍
           </a>
+        </p>
+
+        <p>
+          <a onClick={handleExport}>Export settings</a>
+        </p>
+
+        <p>
+          <a onClick={handleImport}>Import settings</a>
         </p>
 
         <p>

--- a/src/views/settings/Settings.tsx
+++ b/src/views/settings/Settings.tsx
@@ -1,6 +1,6 @@
 import React, { FC, memo, useCallback } from 'react';
 import { FormattedMessage } from 'react-intl';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 
 import { useKeyPress } from '../../hooks';
 import { resetStore, toggleSettings } from '../../store/actions';
@@ -22,7 +22,7 @@ const Settings: FC = () => {
   ]);
   const handleReset = useCallback(() => dispatch(resetStore()), [dispatch]);
   const handleExport = async () => {
-  const { data } = useSelector((state) => state);
+    const { data } = useSelector((state) => state);
     const jsonData = JSON.stringify(data);
     const url = URL.createObjectURL(new Blob([jsonData], { type: 'octet/stream' }));
     const a = document.createElement('a');


### PR DESCRIPTION
Addressing #257, this PR adds a naive method of exporting `LocalStorage` data and prompting the user to download it as a JSON file. Conversely, the user can also restore data by importing the file.

I'm new to React/Redux and there's a lot of advanced stuff going on in the code base which I don't understand. I would greatly appreciate if @joelshepherd or someone could review my changes and refactor as necessary to fit with the rest of the project. Thanks in advance!