### PR TITLE
Move <Overlay> after <Widgets>

### DIFF
--- a/src/views/dashboard/Dashboard.tsx
+++ b/src/views/dashboard/Dashboard.tsx
@@ -17,8 +17,8 @@ const Dashboard: FC = () => {
   return (
     <div className={`Dashboard fullscreen ${theme}`}>
       <Background />
-      <Overlay />
       <Widgets />
+      <Overlay />
     </div>
   );
 };


### PR DESCRIPTION
If a widget is placed on top of the screen, it can cover and make the configuration button over not clickable due to the z-index order.

Update the template and move `<Overlay>` to appear after `<Widgets>`, which solves the z-index problems without CSS changes, and also makes the overlay in a more semantic order.