### PR TITLE
Fix underline leading space in link text on hover

### DIFF
--- a/src/plugins/widgets/links/Display.tsx
+++ b/src/plugins/widgets/links/Display.tsx
@@ -43,8 +43,10 @@ const Display: FC<Props> = ({ icon, name, number, url, linkOpenStyle }) => {
     <a href={url} rel="noopener noreferrer" target={linkOpenStyle ? "_blank" : "_self"} title={title}>
       {icon && <Icon name={icon} />}
       {icon && name && ' '}
-      {name}
-      {!name && !icon && displayUrl(url)}
+      <span className="LinkText">
+        {name}
+        {!name && !icon && displayUrl(url)}
+      </span>
     </a>
   );
 };

--- a/src/plugins/widgets/links/Links.sass
+++ b/src/plugins/widgets/links/Links.sass
@@ -7,3 +7,9 @@
         margin: 0.25em
         white-space: nowrap
 
+        &:hover
+            text-decoration: none
+
+        &:hover
+            .LinkText
+                text-decoration: underline


### PR DESCRIPTION
This fixes a small but annoying cosmetical issue with the "Quick Links" feature.

If an icon **and** a link name (or URL) are displayed in a link, theres a leading whitespace in front of the text for separating the icon from the text. On hover, the complete link text (including the whitespace) is underlined, which is rather unpleasant to the eye:

![tabliss-screenshot-issue](https://user-images.githubusercontent.com/9215743/107358635-e9e9f600-6ad3-11eb-8cde-bc3688447cfc.png)

What this tiny PR does is the following - it looks much less glitchy:

![tabliss-screenshot-fixed](https://user-images.githubusercontent.com/9215743/107358645-ee161380-6ad3-11eb-944d-cc201e49ac0b.png)

I hope this is not too negligible to fix.  
Thank you for this useful extension!