### PR TITLE
Add SearX search engine

### DIFF
--- a/src/plugins/widgets/search/engines.ts
+++ b/src/plugins/widgets/search/engines.ts
@@ -60,4 +60,8 @@ export const engines: Engine[] = [
     name: 'Поиск Mail.Ru',
     search_url: 'https://go.mail.ru/search?q={searchTerms}',
   },
+  {
+    key: 'searx',
+    name: 'SearX',
+    search_url: 'https://searx.laquadrature.net/search?q={searchTerms}',
 ];


### PR DESCRIPTION
This is for [this issue](https://github.com/joelshepherd/tabliss/issues/342). I didn't use [searx.me](https://searx.me/) because that doesn't work on many regions and is often hacked. So I used [searx.laquadrature.net](https://searx.laquadrature.net/) instead.