### PR TITLE
Switched weather api

### DIFF
--- a/src/plugins/widgets/weather/WeatherSettings.tsx
+++ b/src/plugins/widgets/weather/WeatherSettings.tsx
@@ -35,19 +35,10 @@ const WeatherSettings: FC<Props> = ({ data = defaultData, setData }) => (
     <label>
       <input
         type="radio"
-        checked={data.units === 'auto'}
-        onChange={() => setData({ ...data, units: 'auto' })}
-      />{' '}
-      Automatic units (based on location)
-    </label>
-
-    <label>
-      <input
-        type="radio"
         checked={data.units === 'si'}
         onChange={() => setData({ ...data, units: 'si' })}
       />{' '}
-      Metric units
+      Metric units (Fahrenheit)
     </label>
 
     <label>
@@ -56,16 +47,25 @@ const WeatherSettings: FC<Props> = ({ data = defaultData, setData }) => (
         checked={data.units === 'us'}
         onChange={() => setData({ ...data, units: 'us' })}
       />{' '}
-      Imperial units
+      Imperial units (Celsius)
+    </label>
+
+    <label>
+      <input
+        type="radio"
+        checked={data.units === 'standard'}
+        onChange={() => setData({ ...data, units: 'standard' })}
+      />{' '}
+      Kelvin 
     </label>
 
     <p>
       <a
-        href="https://darksky.net/poweredby/"
+        href="https://openweathermap.org/"
         target="_blank"
         rel="noopener noreferrer"
       >
-        Powered by Dark Sky
+        Powered by OpenWeather
       </a>
     </p>
   </div>

--- a/src/plugins/widgets/weather/api.ts
+++ b/src/plugins/widgets/weather/api.ts
@@ -14,9 +14,19 @@ export async function getForecast(
     return;
   }
 
+  if(units == "si"){
+    units = "metric";
+  } else if( units == "us") {
+    units = "imperial";
+  } else if( units == "standard" ) {
+    units = "standard";
+  } else {
+    units = "metric";
+  }
+
   loader.push();
 
-  const url = `${apiEndpoint}/forecast?latitude=${latitude}&longitude=${longitude}&units=${units}`;
+  const url = `api.openweathermap.org/data/2.5/weather?lat=${latitude}&lon=${longitude}&units=${units}&exclude=minutely,hourly,daily,alerts&appid=${apiEndpoint}`;
   const res = await fetch(url);
   const body = await res.json();
 
@@ -24,12 +34,12 @@ export async function getForecast(
 
   return {
     ...body.data,
-    apparentTemperatureHigh: Math.round(body.data.apparentTemperatureHigh),
-    apparentTemperatureLow: Math.round(body.data.apparentTemperatureLow),
-    humidity: Math.round(body.data.humidity * 100),
-    precipProbability: Math.round(body.data.precipProbability * 100),
-    temperatureHigh: Math.round(body.data.temperatureHigh),
-    temperatureLow: Math.round(body.data.temperatureLow),
+    apparentTemperatureHigh: Math.round(body.data.feels_like.day),
+    apparentTemperatureLow: Math.round(body.data.feels_like.night),
+    humidity: Math.round(body.data.humidity),
+    precipProbability: Math.round(body.data.pop),
+    temperatureHigh: Math.round(body.data.temp.day),
+    temperatureLow: Math.round(body.data.temp.night),
   };
 }
 


### PR DESCRIPTION
I switched from the DarkSky API to the OpenWeatherMap API

Why: 
The DarkSky API is getting shut down.

> Our API service for existing customers is not changing today, but we will no longer accept new signups. The API will continue to function through the end of 2021.
https://blog.darksky.net/

Most of the fields have the same name, can be found [here](https://openweathermap.org/darksky-openweather)
Only the probability of precipitation is named a bit differently, its pop now. [Blogpost](https://openweathermap.medium.com/probability-of-precipitation-in-openweather-forecasts-f746db1e8c1)




Also the units are [named a bit differently](https://openweathermap.org/api/one-call-api#data), to not break the settings I just rename them before the query, the only problem is the OpenWeatherMap API does not provide a automatic unit system, so I had to remove it for now.


@joelshepherd, this is of course only a work in progress, because we need a new API key.
