### PR TITLE
Open Unsplash Page in Current Window

### DIFF
--- a/src/plugins/backgrounds/unsplash/UnsplashCredit.tsx
+++ b/src/plugins/backgrounds/unsplash/UnsplashCredit.tsx
@@ -14,8 +14,8 @@ const UnsplashCredit: FC<Props> = ({ image }) => (
 
     <a
       href={image.image_link + UNSPLASH_UTM}
-      rel="noopener noreferrer"
-      target="_blank"
+      rel="noopener noreferrer" 
+      /*target="_blank"*/ // Commenting out this line makes Unsplash open in the foreground.
     >
       <FormattedMessage
         id="plugins.unsplash.photoLink"
@@ -27,7 +27,7 @@ const UnsplashCredit: FC<Props> = ({ image }) => (
     <a
       href={image.user_link + UNSPLASH_UTM}
       rel="noopener noreferrer"
-      target="_blank"
+      /*target="_blank"*/ // Commenting out this line makes Unsplash open in the foreground.
     >
       {image.user_name}
     </a>
@@ -35,7 +35,7 @@ const UnsplashCredit: FC<Props> = ({ image }) => (
     <a
       href={'https://unsplash.com/' + UNSPLASH_UTM}
       rel="noopener noreferrer"
-      target="_blank"
+      /*target="_blank"*/ // Commenting out this line makes Unsplash open in the foreground.
     >
       Unsplash
     </a>


### PR DESCRIPTION
I have an Unsplash account that I use to "Like" images, and if I like the image in a new tab, I do the following:

1. I've just pressed Cmd-T (or Ctrl-T) to open a new tab, which is displaying Tabliss.
2. I want to "Like" the image, so I click [the link in the bottom left](https://github.com/joelshepherd/tabliss/blob/4bad66431d32fa30dfa13e835206af4dd82e7b7e/src/plugins/backgrounds/unsplash/UnsplashCredit.tsx#L15-L25).
3. I don't want to lose my previous train of thought, though, so I immediately press Cmd-T to open another new tab and continue what I was doing (so I can come back to the Unsplash page later).
4. There is now an empty Tabliss tab open in the background in addition to the Unsplash tab.

Basically the problem with opening the Unsplash page in a new tab is that if you're opening and closing tabs using keyboard shortcuts, it's easier to open another new tab than to go back to the previous one, so you end up with an extra empty tab two tabs behind the one you're working in.

In this pull request, I've commented out the `target="_blank"` in each of the links, so that the link will open in the foreground. I haven't tested it, though, because I don't have a full development environment set up, yet. Ideally, the `target` part of the link would be set in the Tabliss preferences, but setting that up is a bit more involved, and I'm still a bit of a React newb, unfortunately.

At some point in the future, I could probably add the preference, though also the links will continue to follow the behavior set the Firefox preferences, so one can Cmd-click to open in a new tab. Also I've been working on [adding an Unsplash "Like" button to Tabliss itself](https://github.com/joelshepherd/tabliss/issues/365), which would make this issue somewhat of a moot point, but it may take me a while because, again, my knowledge of React is beyond rudimentary.

I've left the `target="_blank"` lines the code and commented them out rather than simply removing them mainly because it could be helpful when adding a preference at some point down the line. However, if you'd prefer, I could add another commit or replace the existing one and just delete the lines entirely.

What do you think?