### PR TITLE
[Help or Feedback Needed] Top Sites 

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-  "editor.formatOnSave": true
+  "editor.formatOnSave": true,
+  "typescript.tsdk": "node_modules\\typescript\\lib"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1235,6 +1235,12 @@
       "integrity": "sha1-wFTor02d11205jq8dviFFocU1LM=",
       "dev": true
     },
+    "@types/firefox-webext-browser": {
+      "version": "82.0.0",
+      "resolved": "https://registry.npmjs.org/@types/firefox-webext-browser/-/firefox-webext-browser-82.0.0.tgz",
+      "integrity": "sha512-zKHePkjMx42KIUUZCPcUiyu1tpfQXH9VR4iDYfns3HvmKVJzt/TAFT+DFVroos8BI9RH78YgF3Hi/wlC6R6cKA==",
+      "dev": true
+    },
     "@types/glob": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3545,6 +3545,58 @@
         "sha.js": "^2.4.8"
       }
     },
+    "cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.1"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+          "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
+          }
+        },
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+          "dev": true
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+          "dev": true
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
+    },
     "cross-spawn": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   },
   "devDependencies": {
     "@types/chrome": "0.0.103",
+    "@types/firefox-webext-browser": "^82.0.0",
     "@types/jest": "^25.1.5",
     "@types/node": "^13.11.0",
     "@types/react": "^16.9.32",

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "private": true,
   "scripts": {
     "build": "npm run-script build:web",
-    "build:chromium": "NODE_ENV=production BUILD_TARGET=chromium webpack",
-    "build:firefox": "NODE_ENV=production BUILD_TARGET=firefox webpack",
-    "build:web": "NODE_ENV=production BUILD_TARGET=web webpack",
+    "build:chromium": "cross-env NODE_ENV=production BUILD_TARGET=chromium webpack",
+    "build:firefox": "cross-env NODE_ENV=production BUILD_TARGET=firefox webpack",
+    "build:web": "cross-env NODE_ENV=production BUILD_TARGET=web webpack",
     "start": "webpack-dev-server",
     "test": "jest --config jest.json",
     "translations": "node ./scripts/translations.js"
@@ -43,6 +43,7 @@
     "@types/uuid": "^7.0.2",
     "clean-webpack-plugin": "^3.0.0",
     "copy-webpack-plugin": "^6.1.1",
+    "cross-env": "^7.0.3",
     "css-loader": "^3.4.2",
     "dotenv": "^8.2.0",
     "file-loader": "^6.0.0",

--- a/src/plugins/widgets/index.ts
+++ b/src/plugins/widgets/index.ts
@@ -10,6 +10,7 @@ import search from './search';
 import time from './time';
 import todo from './todo';
 import weather from './weather';
+import topSites from './topSites';
 
 export const widgetConfigs = [
   css,
@@ -23,6 +24,7 @@ export const widgetConfigs = [
   time,
   todo,
   weather,
+  topSites,
 ];
 
 if (process.env.BUILD_TARGET === 'web') {

--- a/src/plugins/widgets/topSites/RectSiteBox.tsx
+++ b/src/plugins/widgets/topSites/RectSiteBox.tsx
@@ -1,0 +1,23 @@
+import React, { FC } from 'react';
+import { TopSite } from './types';
+
+import './TopSites.sass';
+
+interface RectSiteBoxProps {
+    site: TopSite;
+}
+
+const RectSiteBox: FC<RectSiteBoxProps> = ({
+    site
+}) => (
+        <div className='TopSites-card'>
+            {site.favicon && <img src={site.favicon} width='100%' />}
+            <div className='container'>
+                <a href={site.url}>
+                    {site.title}
+                </a>
+            </div>
+        </div>
+    );
+
+export default RectSiteBox;

--- a/src/plugins/widgets/topSites/TopSites.sass
+++ b/src/plugins/widgets/topSites/TopSites.sass
@@ -1,2 +1,17 @@
-.TopSites
-    
+
+.TopSites-flexcontainer 
+  display: flex
+  flex-wrap: wrap
+  justify-content: center
+
+.TopSites-card
+  flex: none
+  box-shadow: 0 4px 8px 0 rgba(0,0,0,0.2)
+  transition: 0.3s
+  width: 100px
+
+.TopSites-card:hover
+  box-shadow: 0 8px 16px 0 rgba(0,0,0,0.2)
+
+.TopSites-container
+  padding: 2px 16px

--- a/src/plugins/widgets/topSites/TopSites.sass
+++ b/src/plugins/widgets/topSites/TopSites.sass
@@ -1,0 +1,2 @@
+.TopSites
+    

--- a/src/plugins/widgets/topSites/TopSites.tsx
+++ b/src/plugins/widgets/topSites/TopSites.tsx
@@ -1,17 +1,20 @@
-import React, { FC, useEffect } from 'react';
-import { Props } from './types';
-
+import React, { FC, useEffect, useState } from 'react';
+import { Props, TopSitesList } from './types';
+import RectSiteBox from './RectSiteBox';
+import './TopSites.sass';
 
 export const TopSites: FC<Props> = () => {
     const namespace: typeof chrome | typeof browser = chrome === undefined ? browser : chrome;
+    const [topSites, setTopSites] = useState<TopSitesList>([]);
+
+    // On mount, check for permissions and request if they aren't present.
+    useEffect(() => {
+        requestTopSitesPermission();
+    }, []);
 
     if (namespace === undefined) {
         return <h4>Your browser does not support Top Sites.</h4>
     }
-
-    useEffect(() => {
-        requestTopSitesPermission();
-    }, []);
 
     const requestTopSitesPermission = async () => {
         try {
@@ -27,14 +30,16 @@ export const TopSites: FC<Props> = () => {
 
         if (namespace === chrome) {
             namespace.topSites.get(console.log);
+            namespace.topSites.get(setTopSites);
         } else if (namespace === browser) {
             console.log(await namespace.topSites.get());
+            setTopSites(await namespace.topSites.get());
         } else {
             console.error('This browser does not expose the Top Sites API.');
         }
     }
 
-    return <div className='TopSites'>
-        {}
+    return <div className='TopSites-flexcontainer'>
+        {topSites.map((site) => <RectSiteBox site={site} />)}
     </div>
 }

--- a/src/plugins/widgets/topSites/TopSites.tsx
+++ b/src/plugins/widgets/topSites/TopSites.tsx
@@ -1,0 +1,40 @@
+import React, { FC, useEffect } from 'react';
+import { Props } from './types';
+
+
+export const TopSites: FC<Props> = () => {
+    const namespace: typeof chrome | typeof browser = chrome === undefined ? browser : chrome;
+
+    if (namespace === undefined) {
+        return <h4>Your browser does not support Top Sites.</h4>
+    }
+
+    useEffect(() => {
+        requestTopSitesPermission();
+    }, []);
+
+    const requestTopSitesPermission = async () => {
+        try {
+            const res = await namespace.permissions.request({
+                permissions: ['topSites']
+            });
+            console.log('Successfully got permissions', res);
+        } catch (e) {
+            // TODO: Error handling? Undo widget add?
+            console.error('Failed to get TopSites permissions.', e);
+            return;
+        }
+
+        if (namespace === chrome) {
+            namespace.topSites.get(console.log);
+        } else if (namespace === browser) {
+            console.log(await namespace.topSites.get());
+        } else {
+            console.error('This browser does not expose the Top Sites API.');
+        }
+    }
+
+    return <div className='TopSites'>
+        {}
+    </div>
+}

--- a/src/plugins/widgets/topSites/TopSitesSettings.tsx
+++ b/src/plugins/widgets/topSites/TopSitesSettings.tsx
@@ -1,9 +1,9 @@
 import React, { FC } from 'react';
 
-import { Props, defaultData } from './types';
+import { Props } from './types';
 
 const TopSitesSettings: FC<Props> = ({
-    data = defaultData,
+    data = { onePerDomain: false },
     setData,
 }) => (
         <div className="TopSitesSettings">

--- a/src/plugins/widgets/topSites/TopSitesSettings.tsx
+++ b/src/plugins/widgets/topSites/TopSitesSettings.tsx
@@ -1,0 +1,23 @@
+import React, { FC } from 'react';
+
+import { Props, defaultData } from './types';
+
+const TopSitesSettings: FC<Props> = ({
+    data = defaultData,
+    setData,
+}) => (
+        <div className="TopSitesSettings">
+            <label>
+                <input
+                    type="checkbox"
+                    checked={data.onePerDomain}
+                    onChange={() =>
+                        setData({ ...data, onePerDomain: !data.onePerDomain })
+                    }
+                />{' '}
+                Ignore duplicate domains (Firefox Only)
+            </label>
+        </div>
+    );
+
+export default TopSitesSettings;

--- a/src/plugins/widgets/topSites/index.ts
+++ b/src/plugins/widgets/topSites/index.ts
@@ -1,0 +1,19 @@
+/**
+ * Top Sites Widget for Tabliss
+ * Forked by Gibryon Bhojraj <gib@rederly.com>
+ * ===
+ * A list of Top Sites, provided by the Browser topSites API. 
+ * This widget requires an optional permission that is requested only if users choose to add this Widget to their dashboard.
+ * @url https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/topSites
+ */
+import { Config } from '../../types';
+import { TopSites } from './TopSites';
+
+const config: Config = {
+    key: 'widget/top-sites',
+    name: 'Top Sites',
+    description: 'Quick links to your top-visited sites.',
+    dashboardComponent: TopSites,
+};
+
+export default config;

--- a/src/plugins/widgets/topSites/types.ts
+++ b/src/plugins/widgets/topSites/types.ts
@@ -1,0 +1,11 @@
+import { API } from '../../types';
+
+export type Data = {
+    onePerDomain: boolean;
+};
+
+export type Cache = {
+    topSites: Array<any>
+}
+
+export type Props = API<Data, Cache>;

--- a/src/plugins/widgets/topSites/types.ts
+++ b/src/plugins/widgets/topSites/types.ts
@@ -9,3 +9,7 @@ export type Cache = {
 }
 
 export type Props = API<Data, Cache>;
+
+export type TopSite = browser.topSites.MostVisitedURL;
+
+export type TopSitesList = Array<TopSite>;

--- a/target/chromium/manifest.json
+++ b/target/chromium/manifest.json
@@ -21,5 +21,6 @@
     "96": "icons/96.png",
     "128": "icons/128.png"
   },
-  "permissions": ["storage"]
+  "permissions": ["storage"],
+  "optional_permissions": ["topSites"]
 }

--- a/target/firefox/manifest.json
+++ b/target/firefox/manifest.json
@@ -19,5 +19,6 @@
     "96": "icons/96.png",
     "128": "icons/128.png"
   },
-  "permissions": ["storage"]
+  "permissions": ["storage"],
+  "optional_permissions": ["topSites"]
 }


### PR DESCRIPTION
I did some very quick throwing together of some functionality as mentioned in #364 to bring the Top Sites API into Tabliss. This functionality was requested in #10 and #98 but was not prioritized because it required additional permissions. I've tested my approach with `optional_permissions` and can approve or reject permission to access the topSites API only when choosing to add this widget to my Tabliss instance.

This is opened as draft because I don't know what style guidelines should be met and this isn't in a sufficiently styled state. Commits are welcome to fix the styling (or anything).

I've also added a lot of developer tooling that I ended up needing to work in my environment, but that can be removed after the PR state is finalized.