### PR TITLE
Remove feedback import from settings

### DIFF
--- a/src/views/settings/Settings.tsx
+++ b/src/views/settings/Settings.tsx
@@ -8,7 +8,6 @@ import { DataState } from "../../store/reducers/types";
 import { Icon } from "../shared";
 import Logo from "../shared/Logo";
 import Background from "./Background";
-import Feedback from "./Feedback";
 import "./Settings.sass";
 import System from "./System";
 import Widgets from "./Widgets";


### PR DESCRIPTION
The current dev build fails due to a prior commit not removing the associated imports for settings. This should fix it.