### PR TITLE
Fixed issue with Giphy not loading images

### DIFF
--- a/src/plugins/backgrounds/giphy/api.ts
+++ b/src/plugins/backgrounds/giphy/api.ts
@@ -25,7 +25,7 @@ export async function getGif(
 
   loader.push();
   const res = await (await fetch(request)).json();
-  const data = await (await fetch(res.data.images.original.url)).blob();
+  const data = await (await fetch(res.data.images.original.webp)).blob();
   loader.pop();
 
   return {

--- a/src/plugins/backgrounds/giphy/api.ts
+++ b/src/plugins/backgrounds/giphy/api.ts
@@ -25,7 +25,7 @@ export async function getGif(
 
   loader.push();
   const res = await (await fetch(request)).json();
-  const data = await (await fetch(res.data.image_original_url)).blob();
+  const data = await (await fetch(res.data.images.original.url)).blob();
   loader.pop();
 
   return {


### PR DESCRIPTION
Giphy changed the way the data in the object is sent. Modified the path to get the original image URL to the correct one in the new Object.