### PR TITLE
Added new block-image button for Unsplash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "@types/react-dom": "^18.0.2",
         "@types/webextension-polyfill": "^0.8.2",
         "clean-webpack-plugin": "^4.0.0",
-        "copy-webpack-plugin": "^10.2.0",
+        "copy-webpack-plugin": "^9.1.0",
         "css-loader": "^6.5.1",
         "dotenv": "^16.0.0",
         "file-loader": "^6.2.0",
@@ -1952,15 +1952,6 @@
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
-    "node_modules/@jest/console/node_modules/slash": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/@jest/core": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/@jest/core/-/core-27.5.1.tgz",
@@ -2021,15 +2012,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@jest/core/node_modules/slash": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/@jest/environment": {
@@ -2122,15 +2104,6 @@
         }
       }
     },
-    "node_modules/@jest/reporters/node_modules/slash": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/@jest/source-map": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-27.5.1.tgz",
@@ -2199,15 +2172,6 @@
       },
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-      }
-    },
-    "node_modules/@jest/transform/node_modules/slash": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/@jest/types": {
@@ -3411,15 +3375,12 @@
       "dev": true
     },
     "node_modules/array-union": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/array-union/-/array-union-3.0.1.tgz",
-      "integrity": "sha512-1OvF9IbWwaeiM9VhzYXVQacMibxpXOMYVNIvMtKRyX9SImBXpKcFr8XvFDeEslCyuH/t6KRt7HEO94AlP8Iatw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
       "dev": true,
       "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=8"
       }
     },
     "node_modules/array-uniq": {
@@ -3526,15 +3487,6 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.8.0"
-      }
-    },
-    "node_modules/babel-jest/node_modules/slash": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/babel-plugin-dynamic-import-node": {
@@ -4408,20 +4360,20 @@
       "dev": true
     },
     "node_modules/copy-webpack-plugin": {
-      "version": "10.2.4",
-      "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-10.2.4.tgz",
-      "integrity": "sha512-xFVltahqlsRcyyJqQbDY6EYTtyQZF9rf+JPjwHObLdPFMEISqkFkr7mFoVOC6BfYS/dNThyoQKvziugm+OnwBg==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-9.1.0.tgz",
+      "integrity": "sha512-rxnR7PaGigJzhqETHGmAcxKnLZSR5u1Y3/bcIv/1FnqXedcL/E2ewK7ZCNrArJKCiSv8yVXhTqetJh8inDvfsA==",
       "dev": true,
       "dependencies": {
         "fast-glob": "^3.2.7",
         "glob-parent": "^6.0.1",
-        "globby": "^12.0.2",
+        "globby": "^11.0.3",
         "normalize-path": "^3.0.0",
-        "schema-utils": "^4.0.0",
+        "schema-utils": "^3.1.1",
         "serialize-javascript": "^6.0.0"
       },
       "engines": {
-        "node": ">= 12.20.0"
+        "node": ">= 12.13.0"
       },
       "funding": {
         "type": "opencollective",
@@ -4429,6 +4381,24 @@
       },
       "peerDependencies": {
         "webpack": "^5.1.0"
+      }
+    },
+    "node_modules/copy-webpack-plugin/node_modules/schema-utils": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
+      "integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
+      "dev": true,
+      "dependencies": {
+        "@types/json-schema": "^7.0.8",
+        "ajv": "^6.12.5",
+        "ajv-keywords": "^3.5.2"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/core-js": {
@@ -6093,20 +6063,20 @@
       }
     },
     "node_modules/globby": {
-      "version": "12.2.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-12.2.0.tgz",
-      "integrity": "sha512-wiSuFQLZ+urS9x2gGPl1H5drc5twabmm4m2gTR27XDFyjUHJUNsS8o/2aKyIF6IoBaR630atdher0XJ5g6OMmA==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
       "dev": true,
       "dependencies": {
-        "array-union": "^3.0.1",
+        "array-union": "^2.1.0",
         "dir-glob": "^3.0.1",
-        "fast-glob": "^3.2.7",
-        "ignore": "^5.1.9",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
         "merge2": "^1.4.1",
-        "slash": "^4.0.0"
+        "slash": "^3.0.0"
       },
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -7301,15 +7271,6 @@
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
-    "node_modules/jest-circus/node_modules/slash": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/jest-cli": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-27.5.1.tgz",
@@ -7385,15 +7346,6 @@
         "ts-node": {
           "optional": true
         }
-      }
-    },
-    "node_modules/jest-config/node_modules/slash": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/jest-diff": {
@@ -7585,15 +7537,6 @@
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
-    "node_modules/jest-message-util/node_modules/slash": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/jest-mock": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-27.5.1.tgz",
@@ -7668,15 +7611,6 @@
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
-    "node_modules/jest-resolve/node_modules/slash": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/jest-runner": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-27.5.1.tgz",
@@ -7740,15 +7674,6 @@
       },
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-      }
-    },
-    "node_modules/jest-runtime/node_modules/slash": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/jest-serializer": {
@@ -10836,15 +10761,12 @@
       "dev": true
     },
     "node_modules/slash": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
-      "integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "dev": true,
       "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=8"
       }
     },
     "node_modules/sliced": {
@@ -14317,14 +14239,6 @@
         "jest-message-util": "^27.5.1",
         "jest-util": "^27.5.1",
         "slash": "^3.0.0"
-      },
-      "dependencies": {
-        "slash": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-          "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-          "dev": true
-        }
       }
     },
     "@jest/core": {
@@ -14371,12 +14285,6 @@
           "requires": {
             "glob": "^7.1.3"
           }
-        },
-        "slash": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-          "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-          "dev": true
         }
       }
     },
@@ -14448,14 +14356,6 @@
         "string-length": "^4.0.1",
         "terminal-link": "^2.0.0",
         "v8-to-istanbul": "^8.1.0"
-      },
-      "dependencies": {
-        "slash": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-          "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-          "dev": true
-        }
       }
     },
     "@jest/source-map": {
@@ -14514,14 +14414,6 @@
         "slash": "^3.0.0",
         "source-map": "^0.6.1",
         "write-file-atomic": "^3.0.0"
-      },
-      "dependencies": {
-        "slash": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-          "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-          "dev": true
-        }
       }
     },
     "@jest/types": {
@@ -15572,9 +15464,9 @@
       "dev": true
     },
     "array-union": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/array-union/-/array-union-3.0.1.tgz",
-      "integrity": "sha512-1OvF9IbWwaeiM9VhzYXVQacMibxpXOMYVNIvMtKRyX9SImBXpKcFr8XvFDeEslCyuH/t6KRt7HEO94AlP8Iatw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
       "dev": true
     },
     "array-uniq": {
@@ -15657,14 +15549,6 @@
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.9",
         "slash": "^3.0.0"
-      },
-      "dependencies": {
-        "slash": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-          "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-          "dev": true
-        }
       }
     },
     "babel-plugin-dynamic-import-node": {
@@ -16338,17 +16222,30 @@
       "dev": true
     },
     "copy-webpack-plugin": {
-      "version": "10.2.4",
-      "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-10.2.4.tgz",
-      "integrity": "sha512-xFVltahqlsRcyyJqQbDY6EYTtyQZF9rf+JPjwHObLdPFMEISqkFkr7mFoVOC6BfYS/dNThyoQKvziugm+OnwBg==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-9.1.0.tgz",
+      "integrity": "sha512-rxnR7PaGigJzhqETHGmAcxKnLZSR5u1Y3/bcIv/1FnqXedcL/E2ewK7ZCNrArJKCiSv8yVXhTqetJh8inDvfsA==",
       "dev": true,
       "requires": {
         "fast-glob": "^3.2.7",
         "glob-parent": "^6.0.1",
-        "globby": "^12.0.2",
+        "globby": "^11.0.3",
         "normalize-path": "^3.0.0",
-        "schema-utils": "^4.0.0",
+        "schema-utils": "^3.1.1",
         "serialize-javascript": "^6.0.0"
+      },
+      "dependencies": {
+        "schema-utils": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
+          "integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
+          "dev": true,
+          "requires": {
+            "@types/json-schema": "^7.0.8",
+            "ajv": "^6.12.5",
+            "ajv-keywords": "^3.5.2"
+          }
+        }
       }
     },
     "core-js": {
@@ -17625,17 +17522,17 @@
       "dev": true
     },
     "globby": {
-      "version": "12.2.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-12.2.0.tgz",
-      "integrity": "sha512-wiSuFQLZ+urS9x2gGPl1H5drc5twabmm4m2gTR27XDFyjUHJUNsS8o/2aKyIF6IoBaR630atdher0XJ5g6OMmA==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
       "dev": true,
       "requires": {
-        "array-union": "^3.0.1",
+        "array-union": "^2.1.0",
         "dir-glob": "^3.0.1",
-        "fast-glob": "^3.2.7",
-        "ignore": "^5.1.9",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
         "merge2": "^1.4.1",
-        "slash": "^4.0.0"
+        "slash": "^3.0.0"
       }
     },
     "globule": {
@@ -18526,14 +18423,6 @@
         "slash": "^3.0.0",
         "stack-utils": "^2.0.3",
         "throat": "^6.0.1"
-      },
-      "dependencies": {
-        "slash": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-          "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-          "dev": true
-        }
       }
     },
     "jest-cli": {
@@ -18586,14 +18475,6 @@
         "pretty-format": "^27.5.1",
         "slash": "^3.0.0",
         "strip-json-comments": "^3.1.1"
-      },
-      "dependencies": {
-        "slash": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-          "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-          "dev": true
-        }
       }
     },
     "jest-diff": {
@@ -18748,14 +18629,6 @@
         "pretty-format": "^27.5.1",
         "slash": "^3.0.0",
         "stack-utils": "^2.0.3"
-      },
-      "dependencies": {
-        "slash": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-          "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-          "dev": true
-        }
       }
     },
     "jest-mock": {
@@ -18797,14 +18670,6 @@
         "resolve": "^1.20.0",
         "resolve.exports": "^1.1.0",
         "slash": "^3.0.0"
-      },
-      "dependencies": {
-        "slash": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-          "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-          "dev": true
-        }
       }
     },
     "jest-resolve-dependencies": {
@@ -18875,14 +18740,6 @@
         "jest-util": "^27.5.1",
         "slash": "^3.0.0",
         "strip-bom": "^4.0.0"
-      },
-      "dependencies": {
-        "slash": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-          "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-          "dev": true
-        }
       }
     },
     "jest-serializer": {
@@ -21267,9 +21124,9 @@
       "dev": true
     },
     "slash": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
-      "integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "dev": true
     },
     "sliced": {

--- a/src/db/action.ts
+++ b/src/db/action.ts
@@ -21,6 +21,31 @@ export const setBackground = (key: string): void => {
   DB.del(cache, current.id);
 };
 
+// Blocked Images Actions
+
+/** Block Unsplash Image */
+
+export const blockImage = (imageID: string): void => {
+
+  //Get the current hashSet of blocked unsplash images
+  const currentBlockedImages = DB.get(db, "blockedImages").imageIds;
+  
+  // Adds the current imageID.
+  currentBlockedImages.add(imageID);
+  
+  // Replaces the blockedImageIDs with the new updated set
+  DB.put(db, "blockedImages", {
+    imageIds: currentBlockedImages    
+  });
+
+};
+
+/** Fetch Blocked Images Set */
+
+export const fetchBlockedImages = (): Set<string> => {
+  return DB.get(db, "blockedImages").imageIds;
+}
+
 // Widget actions
 
 /** Add a new widget */

--- a/src/db/state.ts
+++ b/src/db/state.ts
@@ -7,6 +7,8 @@ import { defaultLocale } from "../locales";
 export interface State {
   /** Background state */
   background: BackgroundState;
+  /** BlockedImages state */
+  blockedImages: BlockedImagesState;
   /** Widget state */
   [key: `widget/${string}`]: WidgetState | null;
   /** Plugin data */
@@ -17,6 +19,10 @@ export interface State {
   locale: string;
   /** Time zone selected, if any */
   timeZone: string | null;
+}
+
+export interface BlockedImagesState {
+  imageIds: Set<string>
 }
 
 export interface BackgroundState {
@@ -65,6 +71,9 @@ const initData: State = {
       luminosity: -0.2,
       blur: 0,
     },
+  },
+  blockedImages: {
+    imageIds: new Set<string>()
   },
   "widget/default-time": {
     id: "default-time",

--- a/src/plugins/backgrounds/unsplash/Unsplash.tsx
+++ b/src/plugins/backgrounds/unsplash/Unsplash.tsx
@@ -5,6 +5,7 @@ import { buildLink, fetchImages } from "./api";
 import { defaultData, Props } from "./types";
 import "./Unsplash.sass";
 import UnsplashCredit from "./UnsplashCredit";
+import { blockImage,fetchBlockedImages } from "../../../db/action";
 
 const Unsplash: React.FC<Props> = ({
   cache,
@@ -64,6 +65,22 @@ const Unsplash: React.FC<Props> = ({
           })
       : null;
 
+  const handleBlock = () => {
+
+    const imageID = item?.credit.imageLink
+    if(imageID == undefined){
+      return;
+    }
+
+    blockImage(imageID)
+    
+    cache && cache.items[cache.cursor + 1] ?  setCache({
+      ...cache!,
+      cursor: cache!.cursor + 1,
+      rotated: Date.now(),
+    }):null;
+  }
+
   const handlePause = () => {
     setData({
       ...data,
@@ -83,6 +100,7 @@ const Unsplash: React.FC<Props> = ({
         <UnsplashCredit
           credit={item.credit}
           paused={data.paused ?? false}
+          onBlock = {handleBlock}
           onPause={handlePause}
           onPrev={go(-1)}
           onNext={go(1)}

--- a/src/plugins/backgrounds/unsplash/UnsplashCredit.tsx
+++ b/src/plugins/backgrounds/unsplash/UnsplashCredit.tsx
@@ -12,6 +12,7 @@ interface Props {
   onPause: () => void;
   onPrev: (() => void) | null;
   onNext: (() => void) | null;
+  onBlock: () => void;
 }
 
 const UnsplashCredit: React.FC<Props> = ({
@@ -20,6 +21,7 @@ const UnsplashCredit: React.FC<Props> = ({
   onPause,
   onPrev,
   onNext,
+  onBlock,
 }) => (
   <div className="credit">
     <div className="photo">
@@ -46,6 +48,9 @@ const UnsplashCredit: React.FC<Props> = ({
       </a>{" "}
       <a onClick={onPause}>
         <Icon name={paused ? "play" : "pause"} />
+      </a>{" "}
+      <a onClick={ () => onBlock() }>
+          <Icon name="x"/>
       </a>{" "}
       <a className={onNext ? "" : "hidden"} onClick={onNext ?? undefined}>
         <Icon name="arrow-right" />

--- a/src/plugins/backgrounds/unsplash/api.ts
+++ b/src/plugins/backgrounds/unsplash/api.ts
@@ -1,4 +1,5 @@
 import { Data, Image } from "./types";
+import { fetchBlockedImages } from "../../../db/action";
 
 export const officialCollection = 1053828;
 
@@ -43,10 +44,27 @@ export const fetchImages = async ({
   }
 
   const res = await fetch(`${url}?${params}`, { headers, cache: "no-cache" });
-  const body = await res.json();
+  var body = await res.json();
+
+  // Fetch blocked image hash-set from DB
+  const blockedImages = fetchBlockedImages();
+  
+  var newBody: any = []
+  var index  = 0
+
+  for (let item of body){
+    // Only use images which are not blocked
+    if(!blockedImages.has(item.links.html)){
+      newBody[index] = item
+      index +=1   
+     }
+  }
+
+  // Replace old body 
+  body = newBody
 
   // TODO: validate types
-
+  
   return body.map((item: any) => ({
     src: item.urls.raw,
     credit: {


### PR DESCRIPTION
I refresh the Unsplash photos quite frequently ( new photo every 5 min), and some of the photos get repeated quite frequently. So I thought it might be useful if we added the ability to block an image (maybe even users at some point).

The bottom credits panel is quite intuitive and useful, so I added the button there. 

However there some **problems** 

- The button can be pressed accidentally and there is no unblock button. Should we add a blocked images section in the settings panel?
- I feel like the blocking mechanism is inefficient, can we control the images we get at an API level? Currently when we get a set of new images we loop through them and remove image objects based on their url. 
```
  var newBody: any = []
  var index  = 0
  for (let item of body){
    // Only use images which are not blocked
    if(!blockedImages.has(item.links.html)){
      newBody[index] = item
      index +=1   
     }
  }
```

- If there is some code that expects the body to be of count 10, unexpected behavior will occur.

### To Do's 

- Unblock Photo
- Better Block Photo Placement ( To avoid misclicks? ) 
- Block User ( For example -> if someone uploads only reptile photos than I might consider blocking them, to avoid jump scares on new tabs lol )  
- Better Filtering Algorithm

Note: I am new to web development, so if I do something stupid let me know :D 

### This is the photo that inspired the PR. 🐊  visits me every few days.
![Screen Shot 2022-04-29 at 9 24 43 PM](https://user-images.githubusercontent.com/76121542/166106575-9283a338-0a11-44a6-843a-51750f32c70f.png)
