### PR TITLE
Feature/joke widget

### DIFF
--- a/src/plugins/widgets/index.ts
+++ b/src/plugins/widgets/index.ts
@@ -14,6 +14,7 @@ import time from "./time";
 import todo from "./todo";
 import weather from "./weather";
 import workHours from "./workHours";
+import joke from "./joke";
 
 export const widgetConfigs = [
   css,
@@ -31,6 +32,7 @@ export const widgetConfigs = [
   todo,
   weather,
   workHours,
+  joke,
 ];
 
 if (BUILD_TARGET === "web") {

--- a/src/plugins/widgets/joke/Joke.sass
+++ b/src/plugins/widgets/joke/Joke.sass
@@ -1,0 +1,5 @@
+.joke-container
+
+  .question-joke-setup
+    &:hover
+      cursor: pointer

--- a/src/plugins/widgets/joke/Joke.tsx
+++ b/src/plugins/widgets/joke/Joke.tsx
@@ -1,0 +1,80 @@
+import React, { useState } from "react";
+import { useCachedEffect } from "../../../hooks";
+import { getJoke } from "./api";
+import "./Joke.sass";
+import {
+  defaultData,
+  Props,
+  isSingleJoke,
+  isTwoPartJoke,
+  TwoPartJokeAPIResponse,
+  isJokeError,
+} from "./types";
+
+const Joke: React.FC<Props> = ({
+  cache,
+  data = defaultData,
+  setCache,
+  loader,
+}) => {
+  useCachedEffect(
+    () => {
+      getJoke(loader, data.category, data.includeNSFW).then(setCache);
+    },
+    0,
+    [data.category],
+  );
+
+  if (!cache) {
+    return null;
+  }
+
+  if (isJokeError(cache)) {
+    return (
+      <>
+        {cache.causedBy.map((errorMessage, index) => {
+          return <p key={index}>{errorMessage}</p>;
+        })}
+      </>
+    );
+  }
+
+  return (
+    <div className="joke-container">
+      {isSingleJoke(cache) && <h5>{cache.joke}</h5>}
+
+      {isTwoPartJoke(cache) && <TwoPartJoke joke={cache} />}
+    </div>
+  );
+};
+
+const TwoPartJoke: React.FC<{ joke: TwoPartJokeAPIResponse }> = ({ joke }) => {
+  const isJokeAQuestion = joke.setup.slice(-1) === "?";
+  const [showAnswer, setShowAnswer] = useState(false);
+
+  if (!isJokeAQuestion) {
+    return (
+      <>
+        <h5>{joke.setup}</h5>
+        <p>. . .</p>
+        <h5>{joke.delivery}</h5>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <h5
+        className="question-joke-setup"
+        onClick={() => setShowAnswer(!showAnswer)}
+      >
+        {joke.setup}
+      </h5>
+      {showAnswer && (
+        <h5 className="question-joke-delivery">{joke.delivery}</h5>
+      )}
+    </>
+  );
+};
+
+export default Joke;

--- a/src/plugins/widgets/joke/Joke.tsx
+++ b/src/plugins/widgets/joke/Joke.tsx
@@ -19,10 +19,13 @@ const Joke: React.FC<Props> = ({
 }) => {
   useCachedEffect(
     () => {
-      getJoke(loader, data.category, data.includeNSFW).then(setCache);
+      loader.push();
+      getJoke(data.categories, data.includeNSFW)
+        .then(setCache)
+        .finally(loader.pop);
     },
-    0,
-    [data.category],
+    cache?.timestamp ? cache.timestamp + data.timeout : 0,
+    [data.categories, data.includeNSFW],
   );
 
   if (!cache) {

--- a/src/plugins/widgets/joke/Joke.tsx
+++ b/src/plugins/widgets/joke/Joke.tsx
@@ -75,7 +75,6 @@ const TwoPartJoke: React.FC<{ joke: TwoPartJokeAPIResponse }> = ({ joke }) => {
     return (
       <>
         <h5>{joke.setup}</h5>
-        <p>. . .</p>
         <h5>{joke.delivery}</h5>
       </>
     );

--- a/src/plugins/widgets/joke/Joke.tsx
+++ b/src/plugins/widgets/joke/Joke.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { useCachedEffect } from "../../../hooks";
 import { getJoke } from "./api";
 import "./Joke.sass";
@@ -54,6 +54,10 @@ const Joke: React.FC<Props> = ({
 const TwoPartJoke: React.FC<{ joke: TwoPartJokeAPIResponse }> = ({ joke }) => {
   const isJokeAQuestion = joke.setup.slice(-1) === "?";
   const [showAnswer, setShowAnswer] = useState(false);
+
+  useEffect(() => {
+    setShowAnswer(false);
+  }, [joke]);
 
   if (!isJokeAQuestion) {
     return (

--- a/src/plugins/widgets/joke/JokeSettings.tsx
+++ b/src/plugins/widgets/joke/JokeSettings.tsx
@@ -44,8 +44,8 @@ const JokeSettings: React.FC<Props> = ({ data = defaultData, setData }) => {
             setData({ ...data, timeout: Number(event.target.value) })
           }
         >
-          <option value={5 * MINUTES * 1000}>Every 5 minutes</option>
-          <option value={15 * MINUTES * 1000}>Every 15 minutes</option>
+          <option value={5 * MINUTES}>Every 5 minutes</option>
+          <option value={15 * MINUTES}>Every 15 minutes</option>
           <option value={HOURS}>Every hour</option>
           <option value={24 * HOURS}>Every day</option>
           <option value={7 * 24 * HOURS}>Every week</option>
@@ -73,17 +73,6 @@ const JokeSettings: React.FC<Props> = ({ data = defaultData, setData }) => {
             </label>
           );
         })}
-      </label>
-
-      <label>
-        <input
-          type="checkbox"
-          checked={data.includeNSFW}
-          onChange={(event) =>
-            setData({ ...data, includeNSFW: event.target.checked })
-          }
-        />{" "}
-        NSFW
       </label>
 
       <p>

--- a/src/plugins/widgets/joke/JokeSettings.tsx
+++ b/src/plugins/widgets/joke/JokeSettings.tsx
@@ -1,51 +1,103 @@
 import React from "react";
+import { MINUTES, HOURS } from "../../../utils";
 
 import categories from "./categories";
 import { Props, defaultData, JokeAPICategory } from "./types";
 
-const JokeSettings: React.FC<Props> = ({ data = defaultData, setData }) => (
-  <div className="JokeSettings">
-    <h5>Daily Joke</h5>
-    <label>
-      Category
-      <select
-        value={data.category}
-        onChange={(event) => {
-          setData({
-            ...data,
-            category: event.target.value as JokeAPICategory,
-          });
-        }}
-      >
+function updateSelectedCategories(
+  existingCategories: Set<JokeAPICategory>,
+  updatedCategory: JokeAPICategory,
+  checked: boolean,
+): Set<JokeAPICategory> {
+  const isAnyCategoryChecked = updatedCategory === "any" && checked;
+  const isLastItemBeingUnchecked = !checked && existingCategories.size === 1;
+
+  if (isLastItemBeingUnchecked) {
+    return existingCategories;
+  }
+
+  if (isAnyCategoryChecked) {
+    return new Set(["any"]);
+  }
+
+  const categories = new Set(existingCategories);
+
+  categories.delete("any");
+
+  checked
+    ? categories.add(updatedCategory)
+    : categories.delete(updatedCategory);
+
+  return categories;
+}
+
+const JokeSettings: React.FC<Props> = ({ data = defaultData, setData }) => {
+  return (
+    <div className="JokeSettings">
+      <h5>Daily Joke</h5>
+
+      <label>
+        Show a new joke
+        <select
+          value={data.timeout}
+          onChange={(event) =>
+            setData({ ...data, timeout: Number(event.target.value) })
+          }
+        >
+          <option value={5 * MINUTES * 1000}>Every 5 minutes</option>
+          <option value={15 * MINUTES * 1000}>Every 15 minutes</option>
+          <option value={HOURS}>Every hour</option>
+          <option value={24 * HOURS}>Every day</option>
+          <option value={7 * 24 * HOURS}>Every week</option>
+        </select>
+      </label>
+      <label>
+        Category
         {categories.map((category) => {
-          const { key, name } = category;
           return (
-            <option key={key} value={key}>
-              {name}
-            </option>
+            <label key={category.key}>
+              <input
+                type="checkbox"
+                checked={data.categories.has(category.key)}
+                onChange={(event) => {
+                  const categories = updateSelectedCategories(
+                    data.categories,
+                    category.key,
+                    event.target.checked,
+                  );
+
+                  setData({ ...data, categories });
+                }}
+              />{" "}
+              {category.name}
+            </label>
           );
         })}
-      </select>
-    </label>
+      </label>
 
-    <label>
-      <input
-        type="checkbox"
-        checked={data.includeNSFW}
-        onChange={(event) =>
-          setData({ ...data, includeNSFW: event.target.checked })
-        }
-      />{" "}
-      Include NSFW
-    </label>
+      <label>
+        <input
+          type="checkbox"
+          checked={data.includeNSFW}
+          onChange={(event) =>
+            setData({ ...data, includeNSFW: event.target.checked })
+          }
+        />{" "}
+        NSFW
+      </label>
 
-    <p>
-      Powered by{" "}
-      <a href="https://jokeapi.dev/" target="_blank" rel="noopener noreferrer">
-        JokeAPI
-      </a>
-    </p>
-  </div>
-);
+      <p>
+        Powered by{" "}
+        <a
+          href="https://jokeapi.dev/"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          JokeAPI
+        </a>
+      </p>
+    </div>
+  );
+};
 
 export default JokeSettings;

--- a/src/plugins/widgets/joke/JokeSettings.tsx
+++ b/src/plugins/widgets/joke/JokeSettings.tsx
@@ -1,0 +1,51 @@
+import React from "react";
+
+import categories from "./categories";
+import { Props, defaultData, JokeAPICategory } from "./types";
+
+const JokeSettings: React.FC<Props> = ({ data = defaultData, setData }) => (
+  <div className="JokeSettings">
+    <h5>Daily Joke</h5>
+    <label>
+      Category
+      <select
+        value={data.category}
+        onChange={(event) => {
+          setData({
+            ...data,
+            category: event.target.value as JokeAPICategory,
+          });
+        }}
+      >
+        {categories.map((category) => {
+          const { key, name } = category;
+          return (
+            <option key={key} value={key}>
+              {name}
+            </option>
+          );
+        })}
+      </select>
+    </label>
+
+    <label>
+      <input
+        type="checkbox"
+        checked={data.includeNSFW}
+        onChange={(event) =>
+          setData({ ...data, includeNSFW: event.target.checked })
+        }
+      />{" "}
+      Include NSFW
+    </label>
+
+    <p>
+      Powered by{" "}
+      <a href="https://jokeapi.dev/" target="_blank" rel="noopener noreferrer">
+        JokeAPI
+      </a>
+    </p>
+  </div>
+);
+
+export default JokeSettings;

--- a/src/plugins/widgets/joke/api.ts
+++ b/src/plugins/widgets/joke/api.ts
@@ -1,0 +1,21 @@
+import { API } from "../../types";
+import { JokeAPICategory, JokeAPIResponse } from "./types";
+
+const url = "https://v2.jokeapi.dev/joke";
+
+export async function getJoke(
+  loader: API["loader"],
+  category?: JokeAPICategory,
+  includeNSFW?: boolean,
+) {
+  loader.push();
+
+  const safeModeUrlParameter = includeNSFW ? "" : "safe-mode";
+
+  const res = await fetch(`${url}/${category}?${safeModeUrlParameter}`);
+  const body: JokeAPIResponse = await res.json();
+
+  loader.pop();
+
+  return body;
+}

--- a/src/plugins/widgets/joke/api.ts
+++ b/src/plugins/widgets/joke/api.ts
@@ -1,4 +1,3 @@
-import { API } from "../../types";
 import { JokeAPICategory, JokeAPIResponse } from "./types";
 
 const url = "https://v2.jokeapi.dev/joke";

--- a/src/plugins/widgets/joke/api.ts
+++ b/src/plugins/widgets/joke/api.ts
@@ -4,13 +4,16 @@ const url = "https://v2.jokeapi.dev/joke";
 
 export async function getJoke(
   categories: Set<JokeAPICategory>,
-  includeNSFW?: boolean,
+  locale: string,
 ) {
-  const safeModeUrlParameter = includeNSFW ? "" : "safe-mode";
+  const languageUrlParameter = `lang=${locale}`;
+  const safeModeUrlParameter = "safe-mode";
   const categoriesUrlParameter = Array.from(categories).join(",");
 
   const res = await fetch(
-    `${url}/${categoriesUrlParameter}?${safeModeUrlParameter}`,
+    // Note: We will always ask jokeapi to return safe jokes for everyone.
+    // This is to comply with content policies (i.e. Hate speech) for all platforms.
+    `${url}/${categoriesUrlParameter}?${safeModeUrlParameter}&${languageUrlParameter}`,
   );
   const body: JokeAPIResponse = await res.json();
 

--- a/src/plugins/widgets/joke/api.ts
+++ b/src/plugins/widgets/joke/api.ts
@@ -4,18 +4,19 @@ import { JokeAPICategory, JokeAPIResponse } from "./types";
 const url = "https://v2.jokeapi.dev/joke";
 
 export async function getJoke(
-  loader: API["loader"],
-  category?: JokeAPICategory,
+  categories: Set<JokeAPICategory>,
   includeNSFW?: boolean,
 ) {
-  loader.push();
-
   const safeModeUrlParameter = includeNSFW ? "" : "safe-mode";
+  const categoriesUrlParameter = Array.from(categories).join(",");
 
-  const res = await fetch(`${url}/${category}?${safeModeUrlParameter}`);
+  const res = await fetch(
+    `${url}/${categoriesUrlParameter}?${safeModeUrlParameter}`,
+  );
   const body: JokeAPIResponse = await res.json();
 
-  loader.pop();
-
-  return body;
+  return {
+    ...body,
+    timestamp: Date.now(),
+  };
 }

--- a/src/plugins/widgets/joke/categories.ts
+++ b/src/plugins/widgets/joke/categories.ts
@@ -1,0 +1,30 @@
+export default [
+  {
+    key: "any",
+    name: "Any",
+  },
+  {
+    key: "misc",
+    name: "Misc",
+  },
+  {
+    key: "programming",
+    name: "Programming",
+  },
+  {
+    key: "dark",
+    name: "Dark",
+  },
+  {
+    key: "pun",
+    name: "Pun",
+  },
+  {
+    key: "spooky",
+    name: "Spooky",
+  },
+  {
+    key: "christmas",
+    name: "Christmas",
+  },
+] as const;

--- a/src/plugins/widgets/joke/categories.ts
+++ b/src/plugins/widgets/joke/categories.ts
@@ -12,10 +12,6 @@ export default [
     name: "Programming",
   },
   {
-    key: "dark",
-    name: "Dark",
-  },
-  {
     key: "pun",
     name: "Pun",
   },

--- a/src/plugins/widgets/joke/index.ts
+++ b/src/plugins/widgets/joke/index.ts
@@ -1,0 +1,13 @@
+import { Config } from "../../types";
+import Joke from "./Joke";
+import JokeSettings from "./JokeSettings";
+
+const config: Config = {
+  key: "widget/joke",
+  name: "Jokes",
+  description: "Some amusement or laughter",
+  dashboardComponent: Joke,
+  settingsComponent: JokeSettings,
+};
+
+export default config;

--- a/src/plugins/widgets/joke/types.ts
+++ b/src/plugins/widgets/joke/types.ts
@@ -1,5 +1,6 @@
 import { API } from "../../types";
 import categories from "./categories";
+import { MINUTES } from "../../../utils";
 
 type JokeAPIType = "single" | "twopart";
 
@@ -18,6 +19,7 @@ type BaseJokeAPIResponse = {
   id: number;
   safe: boolean;
   lang: string;
+  timestamp: number;
 };
 
 export interface SingleJokeAPIResponse extends BaseJokeAPIResponse {
@@ -64,7 +66,8 @@ export function isJokeError(
 
 export type JokeAPICategory = typeof categories[number]["key"];
 export type Data = {
-  category: JokeAPICategory;
+  categories: Set<JokeAPICategory>;
+  timeout: number;
   includeNSFW?: boolean;
 };
 
@@ -73,6 +76,7 @@ export type Cache = JokeAPIResponse;
 export type Props = API<Data, Cache>;
 
 export const defaultData: Data = {
-  category: "any",
+  categories: new Set(["any"]),
   includeNSFW: false,
+  timeout: 5 * MINUTES,
 };

--- a/src/plugins/widgets/joke/types.ts
+++ b/src/plugins/widgets/joke/types.ts
@@ -1,0 +1,78 @@
+import { API } from "../../types";
+import categories from "./categories";
+
+type JokeAPIType = "single" | "twopart";
+
+type BaseJokeAPIResponse = {
+  error: boolean;
+  category: JokeAPICategory;
+  type: JokeAPIType;
+  flags: {
+    nsfw: boolean;
+    religious: boolean;
+    political: boolean;
+    racist: boolean;
+    sexist: boolean;
+    explicit: boolean;
+  };
+  id: number;
+  safe: boolean;
+  lang: string;
+};
+
+export interface SingleJokeAPIResponse extends BaseJokeAPIResponse {
+  joke: string;
+}
+
+export interface TwoPartJokeAPIResponse extends BaseJokeAPIResponse {
+  setup: string;
+  delivery: string;
+}
+
+export type JokeAPIResponse =
+  | SingleJokeAPIResponse
+  | TwoPartJokeAPIResponse
+  | JokeApiErrorResponse;
+
+export type JokeApiErrorResponse = {
+  error: boolean;
+  internalError: boolean;
+  code: number;
+  message: string;
+  causedBy: string[];
+  additionalInfo: string;
+  timestamp: number;
+};
+
+export function isSingleJoke(
+  joke: JokeAPIResponse,
+): joke is SingleJokeAPIResponse {
+  return !joke.error && (joke as SingleJokeAPIResponse).type === "single";
+}
+
+export function isTwoPartJoke(
+  joke: JokeAPIResponse,
+): joke is TwoPartJokeAPIResponse {
+  return !joke.error && (joke as TwoPartJokeAPIResponse).type === "twopart";
+}
+
+export function isJokeError(
+  joke: JokeAPIResponse,
+): joke is JokeApiErrorResponse {
+  return joke.error;
+}
+
+export type JokeAPICategory = typeof categories[number]["key"];
+export type Data = {
+  category: JokeAPICategory;
+  includeNSFW?: boolean;
+};
+
+export type Cache = JokeAPIResponse;
+
+export type Props = API<Data, Cache>;
+
+export const defaultData: Data = {
+  category: "any",
+  includeNSFW: false,
+};

--- a/src/plugins/widgets/joke/types.ts
+++ b/src/plugins/widgets/joke/types.ts
@@ -68,7 +68,6 @@ export type JokeAPICategory = typeof categories[number]["key"];
 export type Data = {
   categories: Set<JokeAPICategory>;
   timeout: number;
-  includeNSFW?: boolean;
 };
 
 export type Cache = JokeAPIResponse;
@@ -77,6 +76,5 @@ export type Props = API<Data, Cache>;
 
 export const defaultData: Data = {
   categories: new Set(["any"]),
-  includeNSFW: false,
   timeout: 5 * MINUTES,
 };


### PR DESCRIPTION
This pull request adds a Joke widget suggested in #483. Its powered by [jokeapi](https://jokeapi.dev/).

The Joke widget options include:

- A selection of supported categories from jokeapi
- Refreshing the joke every x minutes,hours,days
- Displaying single and two part jokes 

Screenshot of options:
![image](https://user-images.githubusercontent.com/26295699/166186202-2b33cde5-94c4-4a82-a71a-bbced4fee3d4.png)

Jokes are categorised into two types, single joke and two-part jokes. Single jokes will display as is whereas two-part jokes will display differently depending on whether it is a question or not. 

If the two-part joke is a question you'll need to click the question to reveal the answer otherwise the delivery and setup will be separated with . . .

Example of a single joke:
![image](https://user-images.githubusercontent.com/26295699/166185910-b4c7cd28-293f-4c22-bf2f-61da36c440d9.png)

Example of two-part joke:
![image](https://user-images.githubusercontent.com/26295699/166186050-1f1bd29f-9564-4940-a869-38ae0b70f6d7.png)

Example of a two-part joke that's a question: 
![image](https://user-images.githubusercontent.com/26295699/166185797-ca66c400-9af2-4a8e-bee0-0a73e6c4c99a.png)

Would love to get some feedback on this PR! 

Thanks
