### PR TITLE
[Feature] Add Bitcoin Mempool widget

### DIFF
--- a/src/plugins/widgets/bitcoin/Bitcoin.sass
+++ b/src/plugins/widgets/bitcoin/Bitcoin.sass
@@ -1,0 +1,62 @@
+.Bitcoin
+    display: flex
+    justify-content: center
+    grid-gap: 2rem
+    padding-top: 2.5rem
+    padding-left: 20px
+    position: relative
+
+    .bitcoin-block
+        background: repeating-linear-gradient(rgb(45, 51, 72), rgb(45, 51, 72) 0.005575%, rgb(147, 57, 244) 0.005575%, rgb(16, 95, 176) 100%)
+        cursor: pointer
+        width: 125px
+        height: 125px
+        position: relative
+        transform: scale(0.9)
+
+        &::after
+            content: ""
+            width: 125px
+            height: 24px
+            position: absolute
+            top: -24px
+            left: -20px
+            background-color: #232838
+            transform: skew(40deg)
+            transform-origin: top
+
+        &::before
+            content: ""
+            width: 20px
+            height: 125px
+            position: absolute
+            top: -12px
+            left: -20px
+            background-color: #191c27
+            transform: skewY(50deg)
+            transform-origin: top
+
+    .block-body
+        display: flex
+        flex-direction: column
+        justify-content: center
+        align-items: center
+        height: 100%
+        padding: 1rem
+        text-align: center
+
+    .block-height
+        font-size: 16px
+        margin-bottom: auto
+
+    .block-size
+        font-size: 18px
+        font-weight: bold
+
+    .transaction-count
+        font-size: 10px
+        margin-top: 4px
+
+    .time-difference
+        font-size: 13px
+        margin-top: auto

--- a/src/plugins/widgets/bitcoin/Bitcoin.tsx
+++ b/src/plugins/widgets/bitcoin/Bitcoin.tsx
@@ -1,0 +1,54 @@
+import React from "react";
+import { formatDistance, fromUnixTime } from "date-fns";
+import { usePushError } from "../../../api";
+import { formatBytes, MINUTES } from "../../../utils";
+import { getBlocks } from "./api";
+import { Props } from "./types";
+import "./Bitcoin.sass";
+
+const BitcoinWidget: React.FC<Props> = ({ cache, setCache, loader }) => {
+  const pushError = usePushError();
+  React.useEffect(() => {
+    getBlocks(loader).then(setCache).catch(pushError);
+
+    const timer = setInterval(
+      () => getBlocks(loader).then(setCache).catch(pushError),
+      2 * MINUTES,
+    );
+
+    return () => clearInterval(timer);
+  }, []);
+
+  if (!cache) {
+    return null;
+  }
+
+  return (
+    <div className="Bitcoin">
+      {cache.map((block) => (
+        <div
+          key={block.id}
+          className="bitcoin-block"
+          onClick={() =>
+            location.assign(`https://mempool.space/block/${block.id}`)
+          }
+        >
+          <div className="block-body">
+            <div className="block-height">{block.height}</div>
+            <div className="block-size">{formatBytes(block.size)}</div>
+            <div className="transaction-count">
+              {block.tx_count} transactions
+            </div>
+            <div className="time-difference">
+              {formatDistance(fromUnixTime(block.timestamp), new Date(), {
+                addSuffix: true,
+              })}
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default BitcoinWidget;

--- a/src/plugins/widgets/bitcoin/api.ts
+++ b/src/plugins/widgets/bitcoin/api.ts
@@ -1,0 +1,13 @@
+import { API } from "../../types";
+import { BlockData } from "./types";
+
+export async function getBlocks(loader: API["loader"]): Promise<BlockData> {
+  loader.push();
+
+  const data: BlockData = await fetch("https://mempool.space/api/blocks")
+    .then((res) => res.json())
+    .finally(() => loader.pop());
+
+  // get last 3 blocks only
+  return data.slice(0, 3);
+}

--- a/src/plugins/widgets/bitcoin/index.ts
+++ b/src/plugins/widgets/bitcoin/index.ts
@@ -1,0 +1,11 @@
+import { Config } from "../../types";
+import BitcoinWidget from "./Bitcoin";
+
+const config: Config = {
+  key: "widget/bitcoin",
+  name: "Bitcoin Mempool",
+  description: "Get the current block height.",
+  dashboardComponent: BitcoinWidget,
+};
+
+export default config;

--- a/src/plugins/widgets/bitcoin/types.ts
+++ b/src/plugins/widgets/bitcoin/types.ts
@@ -1,0 +1,23 @@
+import { API } from "../../types";
+
+export type Data = {};
+
+export type BlockData = {
+  id: string;
+  height: number;
+  version: number;
+  timestamp: number;
+  tx_count: number;
+  size: number;
+  weight: number;
+  merkle_root: string;
+  previousblockhash: string;
+  mediantime: number;
+  nonce: number;
+  bits: number;
+  difficulty: number;
+}[];
+
+type Cache = BlockData;
+
+export type Props = API<Data, Cache>;

--- a/src/plugins/widgets/index.ts
+++ b/src/plugins/widgets/index.ts
@@ -1,3 +1,4 @@
+import bitcoin from "./bitcoin";
 import css from "./css";
 import github from "./github";
 import greeting from "./greeting";
@@ -16,6 +17,7 @@ import weather from "./weather";
 import workHours from "./workHours";
 
 export const widgetConfigs = [
+  bitcoin,
   css,
   github,
   greeting,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,14 @@
 export const SECONDS = 1000;
 export const MINUTES = 60 * SECONDS;
 export const HOURS = 60 * MINUTES;
+
+export const formatBytes = (bytes: number, decimals = 2) => {
+  if (bytes === 0) return "0 Bytes";
+
+  const k = 1024;
+  const dm = decimals < 0 ? 0 : decimals;
+  const sizes = ["Bytes", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"];
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+
+  return parseFloat((bytes / Math.pow(k, i)).toFixed(dm)) + " " + sizes[i];
+};


### PR DESCRIPTION
Adds a widget for [mempool.space](https://mempool.space/) that shows the last 3 mined blocks with their info and re-fetches data every 2 minutes. If for any reason you don't want a Bitcoin related widget in this app that's fine. Just had some fun with this and quickly built something.

![Screenshot_20220502_223508](https://user-images.githubusercontent.com/8538369/166323851-452e866b-1db6-4b9a-b133-6717280e92bf.png)

