### PR TITLE
Hide all extra div elements after GitHub Calendar

### DIFF
--- a/src/plugins/widgets/github/github-calendar.css
+++ b/src/plugins/widgets/github/github-calendar.css
@@ -11,7 +11,7 @@
   --color-calendar-graph-day-L4-bg: #216e39;
 }
 
-.js-calendar-graph-svg + div {
+.js-calendar-graph-svg ~ div {
   display: none;
 }
 


### PR DESCRIPTION
Just a one-liner to hide all the `div`s that appear after the GitHub Calendar. It looks like GitHub just rolled out a new message about [GitHub Skyline](https://skyline.github.com/) on the profile page. The library Tabliss uses picks this up as well as the chart and displays it.

Before: 
<img width="1522" alt="Screenshot 2022-05-05 at 20 21 59" src="https://user-images.githubusercontent.com/15860949/167010567-8df73d20-2299-4430-b433-115a5a0cd471.png">

After:
<img width="1526" alt="Screenshot 2022-05-05 at 20 22 13" src="https://user-images.githubusercontent.com/15860949/167010579-f02ac3ba-5c80-47ed-893d-e6b2388722ac.png">

