### PR TITLE
Feature/nba boxscore links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Updated IP Info widget with a more reliable service and more frequent updates
 
+### Added
+
+- Added boxscore links to NBA games
+
 ## [2.6.0] - 2022-04-25
 
 ### Added

--- a/src/plugins/widgets/nba/Nba.tsx
+++ b/src/plugins/widgets/nba/Nba.tsx
@@ -10,6 +10,9 @@ import { defaultData, Props } from "./types";
 
 const EXPIRE_IN = 1 * MINUTES;
 
+const getLink = (homeTeamCode: string, awayTeamCode: string, gameId: string) =>
+  `https://www.nba.com/game/${awayTeamCode}-vs-${homeTeamCode}-${gameId}/box-score`;
+
 const Nba: React.FC<Props> = ({
   cache,
   data = defaultData,
@@ -35,6 +38,19 @@ const Nba: React.FC<Props> = ({
       {cache.games.map((game) => (
         <div key={game.gameId} className="nba-game">
           <div className="period">{getPeriod(game, timeZone)}</div>
+          <div className="period">
+            <a
+              href={getLink(
+                game.hTeam.triCode,
+                game.vTeam.triCode,
+                game.gameId,
+              )}
+              target="_blank"
+              rel="noreferrer nofollow"
+            >
+              Boxscore
+            </a>
+          </div>
           <div>
             {data.displayLogo ? (
               <img className="icon" src={game.hTeam.logo} />


### PR DESCRIPTION
Added boxscore link to NBA scores: https://github.com/joelshepherd/tabliss/issues/347

Widget:
![image](https://user-images.githubusercontent.com/11281160/179225178-ff29f4a3-b208-499b-8b98-fd527208d964.png)

Boxscore example:
https://www.nba.com/game/MEM-vs-BOS-1522200047/box-score
