### PR TITLE
Update GitHub.tsx

### DIFF
--- a/src/plugins/widgets/github/GitHub.tsx
+++ b/src/plugins/widgets/github/GitHub.tsx
@@ -21,7 +21,7 @@ const GitHubCalendarWidget: FC<Props> = ({ data = defaultData, loader }) => {
   return (
     <div className="GitHub">
       <a
-        href="https://github.com/"
+        href={"https://github.com/" + data.username}
         rel="noopener noreferrer"
         className="GitHubCalendar"
       />


### PR DESCRIPTION
Clicking on GitHub calendar will now open the configured GitHub profile instead of the GitHub homepage.