### PR TITLE
Add ability to set custom search engine

### DIFF
--- a/src/plugins/widgets/search/Search.tsx
+++ b/src/plugins/widgets/search/Search.tsx
@@ -88,7 +88,7 @@ const Search: FC<Props> = ({ data = defaultData }) => {
 
   const search = () => {
     document.location.assign(
-      buildUrl(searchInput.current!.value, getSearchUrl(data.searchEngine)),
+      buildUrl(searchInput.current!.value, getSearchUrl(data.searchEngine, data.searchEngineCustom)),
     );
   };
 

--- a/src/plugins/widgets/search/SearchSettings.tsx
+++ b/src/plugins/widgets/search/SearchSettings.tsx
@@ -1,7 +1,7 @@
 import React, { FC } from "react";
 
 import { engines } from "./engines";
-import { Props, defaultData } from "./types";
+import { Props, defaultData, SEARCH_ENGINE_CUSTOM } from "./types";
 
 const SearchSettings: FC<Props> = ({ data = defaultData, setData }) => (
   <div className="SearchSettings">
@@ -18,8 +18,34 @@ const SearchSettings: FC<Props> = ({ data = defaultData, setData }) => (
             {name}
           </option>
         ))}
+        <option value={SEARCH_ENGINE_CUSTOM}>
+          Custom
+        </option>
       </select>
     </label>
+
+    {data.searchEngine === SEARCH_ENGINE_CUSTOM && (
+      <>
+        <label>
+          Custom Search Provider
+          <input
+            type="text"
+            value={data.searchEngineCustom}
+            onChange={(event) =>
+              setData({
+                ...data,
+                searchEngineCustom: event.target.value,
+              })
+            }
+          />
+        </label>
+
+        <p className="info">
+          Warning: This functionality is intended for advanced users.
+          &#123;searchTerms&#125; is replaced by the entered search term.
+        </p>
+      </>
+    )}
 
     {BUILD_TARGET === "web" && (
       <label>

--- a/src/plugins/widgets/search/types.ts
+++ b/src/plugins/widgets/search/types.ts
@@ -2,6 +2,7 @@ import { API } from "../../types";
 
 type Data = {
   searchEngine: string;
+  searchEngineCustom?: string;
   suggestionsEngine?: string;
   suggestionsQuantity: number;
 };
@@ -12,3 +13,5 @@ export const defaultData: Data = {
   searchEngine: "google",
   suggestionsQuantity: 4,
 };
+
+export const SEARCH_ENGINE_CUSTOM = "CUSTOM";

--- a/src/plugins/widgets/search/utils.ts
+++ b/src/plugins/widgets/search/utils.ts
@@ -1,5 +1,6 @@
 import tlds from "tlds";
 import { engines } from "./engines";
+import { SEARCH_ENGINE_CUSTOM } from "./types";
 
 // TODO: Add unit tests
 export function buildUrl(query: string, engineUrl: string) {
@@ -17,10 +18,12 @@ export function buildUrl(query: string, engineUrl: string) {
   return engineUrl.replace("{searchTerms}", encodeURIComponent(query));
 }
 
-export function getSearchUrl(key: string) {
-  const engine = engines.find((engine) => engine.key === key);
+export function getSearchUrl(key: string, custom?: string) {
+  const engine = key === SEARCH_ENGINE_CUSTOM
+    ? custom
+    : engines.find((engine) => engine.key === key)?.search_url;
 
-  return (engine || engines[0]).search_url;
+  return engine || engines[0].search_url;
 }
 
 export function getSuggestUrl(key?: string) {


### PR DESCRIPTION
Fixes #548, #518, #342, #258, #258 and #197 by adding a option and text input to set a custom search engine to use:

![image](https://user-images.githubusercontent.com/16803954/209450608-cdd8f8ff-3d94-44c0-94b4-d259224068ef.png)
