### PR TITLE
Add HTML widget

### DIFF
--- a/src/plugins/widgets/html/Html.tsx
+++ b/src/plugins/widgets/html/Html.tsx
@@ -1,0 +1,11 @@
+import React, { FC } from "react";
+
+import { Props, defaultData } from "./types";
+
+const Html: FC<Props> = ({ data = defaultData }) => {
+  return (
+    <div className="Html" dangerouslySetInnerHTML={{ __html: data.input }}></div>
+  );
+};
+
+export default Html;

--- a/src/plugins/widgets/html/HtmlSettings.tsx
+++ b/src/plugins/widgets/html/HtmlSettings.tsx
@@ -1,0 +1,35 @@
+import React, { FC, useState } from "react";
+
+import { Props, defaultData } from "./types";
+
+const HtmlSettings: FC<Props> = ({ data = defaultData, setData }) => {
+  const [input, setInput] = useState(data.input);
+  const handleSave = () => setData({ input });
+
+  return (
+    <div className="HtmlSettings">
+      <label>
+        HTML Snippet
+        <textarea
+          rows={3}
+          style={{ fontFamily: "monospace" }}
+          value={input}
+          onChange={(event) => setInput(event.target.value)}
+        />
+      </label>
+
+      <p className="info">
+        Warning: This functionality is intended for advanced users.
+        {BUILD_TARGET !== "web" && (
+          <>
+            &nbsp;JavaScript will not be executed.
+          </>
+        )}
+      </p>
+
+      <button onClick={handleSave}>Apply</button>
+    </div>
+  );
+};
+
+export default HtmlSettings;

--- a/src/plugins/widgets/html/index.ts
+++ b/src/plugins/widgets/html/index.ts
@@ -1,0 +1,13 @@
+import { Config } from "../../types";
+import Html from "./Html";
+import HtmlSettings from "./HtmlSettings";
+
+const config: Config = {
+  key: "widget/html",
+  name: "Custom HTML",
+  description: "Add static HTML (advanced users).",
+  dashboardComponent: Html,
+  settingsComponent: HtmlSettings,
+};
+
+export default config;

--- a/src/plugins/widgets/html/types.ts
+++ b/src/plugins/widgets/html/types.ts
@@ -1,0 +1,11 @@
+import { API } from "../../types";
+
+type Data = {
+  input: string;
+};
+
+export type Props = API<Data>;
+
+export const defaultData: Data = {
+  input: "",
+};

--- a/src/plugins/widgets/index.ts
+++ b/src/plugins/widgets/index.ts
@@ -1,6 +1,7 @@
 import css from "./css";
 import github from "./github";
 import greeting from "./greeting";
+import html from "./html";
 import ipInfo from "./ipInfo";
 import js from "./js";
 import links from "./links";
@@ -20,6 +21,7 @@ export const widgetConfigs = [
   css,
   github,
   greeting,
+  html,
   ipInfo,
   links,
   literatureClock,


### PR DESCRIPTION
Fixes #520 by adding a Custom HTML widget.

As JavaScript does not work in the extension version a warning is displayed when using that version.

![image](https://user-images.githubusercontent.com/16803954/209452088-393bc287-917f-48b9-9444-04d4e4f7c7c1.png)
