### PR TITLE
Fix label for german language in language selector

### DIFF
--- a/src/views/settings/System.tsx
+++ b/src/views/settings/System.tsx
@@ -42,7 +42,7 @@ const System: React.FC = () => {
             Čeština
           </option>
           <option value="de" title="German">
-            DeutscH
+            Deutsch
           </option>
           <option value="el" title="Greek">
             Ελληνικά


### PR DESCRIPTION
The label for the german language is spelled with a capital H at the end:

![image](https://user-images.githubusercontent.com/16803954/209452624-dc6a4af0-eb58-48ee-b688-1e652f0ad9c8.png)

This PR corrects this to:

![image](https://user-images.githubusercontent.com/16803954/209452631-bba78578-7b39-4a7e-b41d-efa1f16a1b43.png)