### PR TITLE
Read location correctly from Unsplash API response

### DIFF
--- a/src/plugins/backgrounds/unsplash/api.ts
+++ b/src/plugins/backgrounds/unsplash/api.ts
@@ -51,7 +51,7 @@ export const fetchImages = async ({
     src: item.urls.raw,
     credit: {
       imageLink: item.links.html,
-      location: item.location ? item.location.title : null,
+      location: item.location ? item.location.name : null,
       userName: item.user.name,
       userLink: item.user.links.html,
     },


### PR DESCRIPTION
Full location is returned in location.name according to https://unsplash.com/documentation#get-a-random-photo

Fixes #544