### PR TITLE
VS Code Dev Containers config

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,27 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/typescript-node
+{
+  "name": "Node.js & TypeScript",
+  // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:0-18",
+  "customizations": {
+    "vscode": {
+      "extensions": ["esbenp.prettier-vscode", "syler.sass-indented"]
+    }
+  }
+
+  // Features to add to the dev container. More info: https://containers.dev/features.
+  // "features": {},
+
+  // Use 'forwardPorts' to make a list of ports inside the container available locally.
+  // "forwardPorts": [],
+
+  // Use 'postCreateCommand' to run commands after the container is created.
+  // "postCreateCommand": "yarn install",
+
+  // Configure tool-specific properties.
+  // "customizations": {},
+
+  // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+  // "remoteUser": "root"
+}

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
NPM scripts fail in Windows because they are setting environment variables without using [cross-env](https://www.npmjs.com/package/cross-env) or similar. [VS Code Dev Containers](https://code.visualstudio.com/docs/devcontainers/containers) are probably the simplest way to make it work in Windows without any code changes, at least for Visual Studio Code users.

The commit contains a configuration file with the default image for TypeScript development with latest Node.js version and two extensions that make a lot of sense for the project:
- [Prettier - Code formatter](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode)
- [Sass](https://marketplace.visualstudio.com/items?itemName=Syler.sass-indented)

The `.gitattributes` file forces LF line endings to avoid problems with phantom file changes when cloning the project in Windows and using Git inside the Dev Container.

Having these 2 files in the repository should make it much easier to get to a working development environment in Windows.