### PR TITLE
Add: Add daily routine feature to Todo widget

### DIFF
--- a/src/plugins/widgets/todo/README.md
+++ b/src/plugins/widgets/todo/README.md
@@ -1,3 +1,5 @@
 # plugin/todo
 
 A simple todo plugin for Tabliss.
+
+If **Daily routine** is set, the done items are restored every morning at 00:00.

--- a/src/plugins/widgets/todo/Todo.tsx
+++ b/src/plugins/widgets/todo/Todo.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from "react";
+import React, { FC, useEffect } from "react";
 
 import { useKeyPress, useSavedReducer, useToggle } from "../../../hooks";
 import { DownIcon, Icon, UpIcon, ExpandIcon } from "../../../views/shared";
@@ -25,6 +25,20 @@ const Todo: FC<Props> = ({ data = defaultData, setData }) => {
     },
     [keyBind.toUpperCase(), keyBind.toLowerCase()],
   );
+
+  useEffect(() => {
+    if (data.dailyRoutine) {
+      const today = new Date();
+      today.setHours(0, 0, 0, 0);
+      for (const item of items) {
+        if (item.completed && item.completedAt) {
+          if (new Date(item.completedAt).getTime() < today.getTime()) {
+            dispatch(toggleTodo(item.id));
+          }
+        }
+      }
+    }
+  }, [data.items, data.dailyRoutine]);
 
   return (
     <div className="Todo">

--- a/src/plugins/widgets/todo/TodoSettings.tsx
+++ b/src/plugins/widgets/todo/TodoSettings.tsx
@@ -22,11 +22,21 @@ const TodoSettings: FC<Props> = ({ data = defaultData, setData }) => (
       <input
         type="text"
         maxLength={1}
-        onChange={(event) =>
-          setData({ ...data, keyBind: event.target.value })
-        }
+        onChange={(event) => setData({ ...data, keyBind: event.target.value })}
         value={data.keyBind}
       />
+    </label>
+
+    <label>
+      <input
+        type="checkbox"
+        maxLength={1}
+        onChange={(event) =>
+          setData({ ...data, dailyRoutine: event.target.checked })
+        }
+        checked={data.dailyRoutine}
+      />
+      Daily routine
     </label>
   </div>
 );

--- a/src/plugins/widgets/todo/actions.ts
+++ b/src/plugins/widgets/todo/actions.ts
@@ -7,6 +7,7 @@ export function addTodo(contents = "") {
       contents,
       id: generateId(),
       completed: false,
+      completedAt: null,
     },
   } as const;
 }

--- a/src/plugins/widgets/todo/reducer.test.ts
+++ b/src/plugins/widgets/todo/reducer.test.ts
@@ -8,6 +8,7 @@ describe("todo/reducer", () => {
         id: expect.any(String),
         contents: "Test todo",
         completed: false,
+        completedAt: null,
       },
     ]);
 
@@ -18,6 +19,7 @@ describe("todo/reducer", () => {
             id: "1234",
             contents: "Existing todo",
             completed: true,
+            completedAt: "2022-30-12T12:44:38",
           },
         ],
         addTodo("Test todo"),
@@ -27,11 +29,13 @@ describe("todo/reducer", () => {
         id: "1234",
         contents: "Existing todo",
         completed: true,
+        completedAt: "2022-30-12T12:44:38",
       },
       {
         id: expect.any(String),
         contents: "Test todo",
         completed: false,
+        completedAt: null,
       },
     ]);
   });
@@ -44,6 +48,7 @@ describe("todo/reducer", () => {
             id: "1234",
             contents: "Existing todo",
             completed: true,
+            completedAt: "2022-30-12T12:44:38",
           },
         ],
         removeTodo("1234"),
@@ -57,11 +62,13 @@ describe("todo/reducer", () => {
             id: "1234",
             contents: "Existing todo",
             completed: true,
+            completedAt: "2022-30-12T12:44:38",
           },
           {
             id: "5678",
             contents: "Second existing todo",
             completed: false,
+            completedAt: null,
           },
         ],
         removeTodo("1234"),
@@ -71,6 +78,7 @@ describe("todo/reducer", () => {
         id: "5678",
         contents: "Second existing todo",
         completed: false,
+        completedAt: null,
       },
     ]);
   });
@@ -83,11 +91,13 @@ describe("todo/reducer", () => {
             id: "1234",
             contents: "Existing todo",
             completed: true,
+            completedAt: "2022-30-12T12:44:38",
           },
           {
             id: "5678",
             contents: "Second existing todo",
             completed: false,
+            completedAt: null,
           },
         ],
         toggleTodo("1234"),
@@ -97,11 +107,13 @@ describe("todo/reducer", () => {
         id: "1234",
         contents: "Existing todo",
         completed: false,
+        completedAt: null,
       },
       {
         id: "5678",
         contents: "Second existing todo",
         completed: false,
+        completedAt: null,
       },
     ]);
 
@@ -112,11 +124,13 @@ describe("todo/reducer", () => {
             id: "1234",
             contents: "Existing todo",
             completed: true,
+            completedAt: "2022-30-12T12:44:38",
           },
           {
             id: "5678",
             contents: "Second existing todo",
             completed: false,
+            completedAt: null,
           },
         ],
         toggleTodo("5678"),
@@ -126,11 +140,13 @@ describe("todo/reducer", () => {
         id: "1234",
         contents: "Existing todo",
         completed: true,
+        completedAt: "2022-30-12T12:44:38",
       },
       {
         id: "5678",
         contents: "Second existing todo",
         completed: true,
+        completedAt: expect.stringMatching(/[0-9TZ:-]+/),
       },
     ]);
   });
@@ -143,11 +159,13 @@ describe("todo/reducer", () => {
             id: "1234",
             contents: "Existing todo",
             completed: true,
+            completedAt: "2022-30-12T12:44:38",
           },
           {
             id: "5678",
             contents: "Second existing todo",
             completed: false,
+            completedAt: null
           },
         ],
         updateTodo("1234", "Existing todo: edited"),
@@ -157,11 +175,13 @@ describe("todo/reducer", () => {
         id: "1234",
         contents: "Existing todo: edited",
         completed: true,
+        completedAt: "2022-30-12T12:44:38"
       },
       {
         id: "5678",
         contents: "Second existing todo",
         completed: false,
+        completedAt: null,
       },
     ]);
   });
@@ -174,11 +194,13 @@ describe("todo/reducer", () => {
             id: "1234",
             contents: "Existing todo",
             completed: true,
+            completedAt: "2022-30-12T12:44:38",
           },
           {
             id: "5678",
             contents: "Second existing todo",
             completed: false,
+            completedAt: null,
           },
         ],
         updateTodo("5678", ""),
@@ -188,6 +210,7 @@ describe("todo/reducer", () => {
         id: "1234",
         contents: "Existing todo",
         completed: true,
+        completedAt: "2022-30-12T12:44:38"
       },
     ]);
   });

--- a/src/plugins/widgets/todo/reducer.ts
+++ b/src/plugins/widgets/todo/reducer.ts
@@ -4,6 +4,7 @@ type Todo = {
   id: string;
   contents: string;
   completed: boolean;
+  completedAt: string | null;
 };
 
 export type State = Todo[];
@@ -19,7 +20,7 @@ export function reducer(state: State, action: Action) {
     case "TOGGLE_TODO":
       return state.map((todo) =>
         todo.id === action.data.id
-          ? { ...todo, completed: !todo.completed }
+          ? { ...todo, completed: !todo.completed, completedAt: todo.completed ? null : new Date().toISOString() }
           : todo,
       );
 

--- a/src/plugins/widgets/todo/types.ts
+++ b/src/plugins/widgets/todo/types.ts
@@ -5,6 +5,7 @@ export type Data = {
   items: State;
   show: number;
   keyBind?: string;
+  dailyRoutine: boolean;
 };
 
 export type Props = API<Data>;
@@ -13,4 +14,5 @@ export const defaultData: Data = {
   items: [],
   show: 3,
   keyBind: "T",
+  dailyRoutine: false,
 };


### PR DESCRIPTION
Hello,
This is an extension for the TODO widget. I need to turn it into a "Daily routine" thing, so that every item is unchecked every day, so that i can keep track of all the recurring stuffs that I need to to.

I'm not an expert in front-end development, so any suggestion is welcome.
Should this be kept as an extension of the TODO widget or should it be a standalone one?