### PR TITLE
[FEATURE] 'Display time' in Time widget

### DIFF
--- a/src/plugins/widgets/time/Time.tsx
+++ b/src/plugins/widgets/time/Time.tsx
@@ -14,6 +14,7 @@ const Time: FC<Props> = ({ data = defaultData }) => {
     mode,
     name,
     showDate,
+    showTime,
     showMinutes,
     showSeconds,
     timeZone,
@@ -27,26 +28,35 @@ const Time: FC<Props> = ({ data = defaultData }) => {
 
   return (
     <div className="Time">
-      {mode === "analogue" ? (
-        <Analogue
-          time={time}
-          showMinutes={showMinutes}
-          showSeconds={showSeconds}
-        />
-      ) : (
-        <Digital
-          time={time}
-          hour12={hour12}
-          showMinutes={showMinutes}
-          showSeconds={showSeconds}
-          showDayPeriod={showDayPeriod}
-        />
+      {showTime && (
+        <>
+          {mode === "analogue" ? (
+            <Analogue
+              time={time}
+              showMinutes={showMinutes}
+              showSeconds={showSeconds}
+            />
+          ) : (
+            <Digital
+              time={time}
+              hour12={hour12}
+              showMinutes={showMinutes}
+              showSeconds={showSeconds}
+              showDayPeriod={showDayPeriod}
+            />
+          )}
+        </>
       )}
-      {name && <h2>{name}</h2>}
+
+      {name && (
+        <h2>{name}</h2>
+      )}
 
       {showDate && (
         <>
-          <hr />
+          {(showTime || name) && (
+            <hr />
+          )}
           <h3>
             <FormattedDate
               value={time}

--- a/src/plugins/widgets/time/TimeSettings.tsx
+++ b/src/plugins/widgets/time/TimeSettings.tsx
@@ -25,60 +25,73 @@ const TimeSettings: FC<Props> = ({ data = defaultData, setData }) => (
 
     <label>
       <input
-        type="radio"
-        checked={data.mode === "analogue"}
-        onChange={() => setData({ ...data, mode: "analogue" })}
-      />{" "}
-      Analogue
-    </label>
-
-    <label>
-      <input
-        type="radio"
-        checked={data.mode === "digital" && data.hour12}
-        onChange={() => setData({ ...data, mode: "digital", hour12: true })}
-      />{" "}
-      12-hour digital
-    </label>
-
-    <label>
-      <input
-        type="radio"
-        checked={data.mode === "digital" && !data.hour12}
-        onChange={() => setData({ ...data, mode: "digital", hour12: false })}
-      />{" "}
-      24-hour digital
-    </label>
-
-    <label>
-      <input
         type="checkbox"
-        checked={data.showSeconds}
-        onChange={() => setData({ ...data, showSeconds: !data.showSeconds })}
+        checked={data.showTime}
+        onChange={() => setData({ ...data, showTime: !data.showTime })}
       />{" "}
-      Display seconds
+      Display time
     </label>
 
-    <label>
-      <input
-        type="checkbox"
-        checked={data.showMinutes}
-        onChange={() => setData({ ...data, showMinutes: !data.showMinutes })}
-      />{" "}
-      Display minutes
-    </label>
+    {data.showTime && (
+    <>
+      <label>
+        <input
+          type="radio"
+          checked={data.mode === "analogue"}
+          onChange={() => setData({ ...data, mode: "analogue" })}
+        />{" "}
+        Analogue
+      </label>
 
-    {data.mode === "digital" && data.hour12 && (
+      <label>
+        <input
+          type="radio"
+          checked={data.mode === "digital" && data.hour12}
+          onChange={() => setData({ ...data, mode: "digital", hour12: true })}
+        />{" "}
+        12-hour digital
+      </label>
+
+      <label>
+        <input
+          type="radio"
+          checked={data.mode === "digital" && !data.hour12}
+          onChange={() => setData({ ...data, mode: "digital", hour12: false })}
+        />{" "}
+        24-hour digital
+      </label>
+
       <label>
         <input
           type="checkbox"
-          checked={data.showDayPeriod}
-          onChange={() =>
-            setData({ ...data, showDayPeriod: !data.showDayPeriod })
-          }
+          checked={data.showSeconds}
+          onChange={() => setData({ ...data, showSeconds: !data.showSeconds })}
         />{" "}
-        Display day period
+        Display seconds
       </label>
+
+      <label>
+        <input
+          type="checkbox"
+          checked={data.showMinutes}
+          onChange={() => setData({ ...data, showMinutes: !data.showMinutes })}
+        />{" "}
+        Display minutes
+      </label>
+
+      {data.mode === "digital" && data.hour12 && (
+        <label>
+          <input
+            type="checkbox"
+            checked={data.showDayPeriod}
+            onChange={() =>
+              setData({ ...data, showDayPeriod: !data.showDayPeriod })
+            }
+          />{" "}
+          Display day period
+        </label>
+      )}
+    </>
     )}
 
     <label>

--- a/src/plugins/widgets/time/types.ts
+++ b/src/plugins/widgets/time/types.ts
@@ -4,6 +4,7 @@ type Data = {
   hour12: boolean;
   mode: "analogue" | "digital";
   showDate: boolean;
+  showTime: boolean;
   showMinutes: boolean;
   showSeconds: boolean;
   showDayPeriod?: boolean;
@@ -17,6 +18,7 @@ export const defaultData: Data = {
   mode: "digital",
   hour12: false,
   showDate: false,
+  showTime: true,
   showMinutes: true,
   showSeconds: false,
   showDayPeriod: true,


### PR DESCRIPTION
This PR adds a posibility to hide clock part in Time widget. (so user can display 'date' related part only)

Changes:
- 'Display time' checkbox (which triggers display of 'time' related settings) in Time widget settings
- If time/name part is not set, hides `<hr />`

Result:

![time-widget-update](https://user-images.githubusercontent.com/7910857/216180078-3b8861e4-ba79-413f-a9f1-e7727892d41f.png)
