### PR TITLE
Add transform to widget

### DIFF
--- a/src/views/dashboard/Widget.tsx
+++ b/src/views/dashboard/Widget.tsx
@@ -15,6 +15,7 @@ const Widget: React.FC<React.PropsWithChildren<WidgetDisplay>> = ({
       fontFamily,
       fontSize: `${fontSize}px`,
       fontWeight,
+      transform: `scale(${fontSize / 100})`
     }}
   >
     {children}

--- a/src/views/dashboard/Widget.tsx
+++ b/src/views/dashboard/Widget.tsx
@@ -15,7 +15,7 @@ const Widget: React.FC<React.PropsWithChildren<WidgetDisplay>> = ({
       fontFamily,
       fontSize: `${fontSize}px`,
       fontWeight,
-      transform: `scale(${fontSize / 100})`
+      transform: `scale(${fontSize / 50})`,
     }}
   >
     {children}


### PR DESCRIPTION
#579 is wondering why the GitHub Calendar isn't scalable. This should allow any type of widget to scale with the size slider.

No idea if this will be a useful or desirable change, and I should also add that **this seems to cause a regression** where all existing configs will become broken and all widgets will become small (resizing them will fix it). If you have any idea how to fix that, please let me know.

I originally wanted to just have the github widget scale, but I'm not familiar with React so I wasn't sure how to do it. I've been playing about trying to figure out how to get the child node names etc and just applying transform on the GitHub calendar but with no luck

I've wanted to contribute to this project for a while but no idea if this idea stinks or not, or how to fix the issues I'm having. If you have any advice I'd love to hear it!