### PR TITLE
Include neeva search engine in the search box widget

### DIFF
--- a/src/plugins/widgets/search/engines.ts
+++ b/src/plugins/widgets/search/engines.ts
@@ -87,4 +87,9 @@ export const engines: Engine[] = [
     name: "Phind",
     search_url: "https://phind.com/search?q={searchTerms}",
   },
+  {
+    key: "neeva",
+    name: "Neeva",
+    search_url: "https://neeva.com/search?q={searchTerms}",
+  },
 ];


### PR DESCRIPTION
This PR adds [neeva](https://neeva.com/) search engine option to the search box widget.
Everything was tested on the latest Firefox and Chromium, I've found no issues.

`suggest_url` could also be potentially added but they use GraphQL for providing suggestions, upon the first look it's not a simple change so I'm leaving it out for now.
