### PR TITLE
Update Links.tsx -> fix button shift when columns > 1

### DIFF
--- a/src/plugins/widgets/links/Links.tsx
+++ b/src/plugins/widgets/links/Links.tsx
@@ -25,7 +25,7 @@ const Links: FC<Props> = ({ data = defaultData }) => {
     <div
       className="Links"
       style={{
-        gridTemplateColumns: "1fr ".repeat(data.columns),
+        gridTemplateColumns: data.visible || visible ? "1fr ".repeat(data.columns) : "1fr",
         textAlign: data.columns > 1 ? "left" : "inherit",
       }}
     >


### PR DESCRIPTION
When you set the "columns" parameter to a value greater than 1, the button used to display the links no longer shifts to the left and remains centered

Before : 
![image](https://user-images.githubusercontent.com/39917969/231483143-a527295a-a5d6-499d-9a9c-4cdb1237053c.png)

After : 
![image](https://user-images.githubusercontent.com/39917969/231483462-7e2e333c-3a3c-428a-8836-7e5700843442.png)
