### PR TITLE
[FEATURE] Add 'show city name' setting to the Weather plugin

### DIFF
--- a/src/plugins/widgets/weather/Weather.sass
+++ b/src/plugins/widgets/weather/Weather.sass
@@ -3,6 +3,9 @@
     .summary
         cursor: pointer
 
+        i:first-child
+            margin-left: 0
+
         i
             margin: 0 0.5em
 

--- a/src/plugins/widgets/weather/Weather.tsx
+++ b/src/plugins/widgets/weather/Weather.tsx
@@ -42,7 +42,7 @@ const Weather: React.FC<Props> = ({
         onClick={() => setData({ ...data, showDetails: !data.showDetails })}
         title="Toggle weather details"
       >
-        {data.name ? <span>{data.name}</span> : null}
+        {data.name && data.showCity ? <span>{data.name}</span> : null}
         <Icon name={weatherCodes[conditions.weatherCode]} />
         <span className="temperature">
           {Math.round(conditions.temperature)}˚

--- a/src/plugins/widgets/weather/WeatherSettings.tsx
+++ b/src/plugins/widgets/weather/WeatherSettings.tsx
@@ -39,6 +39,18 @@ const WeatherSettings: FC<Props> = ({ data = defaultData, setData }) => (
 
         <label>
           <input
+            type="checkbox"
+            checked={data.showCity}
+            onChange={() =>
+              setData({ ...data, showCity: !data.showCity })
+            }
+          />{" "}
+          Show city name
+        </label>
+
+
+        <label>
+          <input
             type="radio"
             checked={data.units === "si"}
             onChange={() => setData({ ...data, units: "si" })}

--- a/src/plugins/widgets/weather/types.ts
+++ b/src/plugins/widgets/weather/types.ts
@@ -9,6 +9,7 @@ export type Coordinates = {
 export type Data = Coordinates & {
   name?: string;
   showDetails: boolean;
+  showCity: boolean;
   units: "auto" | "si" | "us"; // `auto` has been removed, but may still be present in settings
 };
 
@@ -23,5 +24,6 @@ export type Props = API<Data, Cache>;
 
 export const defaultData: Data = {
   showDetails: false,
+  showCity: true,
   units: "si",
 };


### PR DESCRIPTION
This PR adds the ability to hide city name to the Weather widget
![image](https://github.com/joelshepherd/tabliss/assets/3050013/129d2181-0ba9-43a3-ba99-92e7d162f52e)
