### PR TITLE
Add mask ip option to IP info widget

### DIFF
--- a/src/plugins/widgets/ipInfo/IpInfo.tsx
+++ b/src/plugins/widgets/ipInfo/IpInfo.tsx
@@ -18,7 +18,8 @@ const IpInfo: React.FC<Props> = ({
     return null;
   }
 
-  const info = [cache.ip];
+  const ip = data.maskIP ? cache.ip.split('.').map((s, i) => i > 0 && i < 3 ? s.replace(/[\d]+/, '*') : s).join('.') : cache.ip;
+  const info = [ip];
   if (data.displayCity) info.push(cache.city);
   if (data.displayCountry) info.push(cache.country);
 

--- a/src/plugins/widgets/ipInfo/IpInfoSettings.tsx
+++ b/src/plugins/widgets/ipInfo/IpInfoSettings.tsx
@@ -22,6 +22,17 @@ const IpInfoSettings: React.FC<Props> = ({ data = defaultData, setData }) => (
       />
       Display Country
     </label>
+
+    <label>
+      <input
+        type="checkbox"
+        checked={data.maskIP}
+        onChange={() =>
+          setData({ ...data, maskIP: !data.maskIP })
+        }
+      />
+      Mask IP
+    </label>
   </div>
 );
 

--- a/src/plugins/widgets/ipInfo/types.ts
+++ b/src/plugins/widgets/ipInfo/types.ts
@@ -3,6 +3,7 @@ import { API } from "../../types";
 type Data = {
   displayCity: boolean;
   displayCountry: boolean;
+  maskIP: boolean;
 };
 
 export type IpData = {
@@ -18,4 +19,5 @@ export type Props = API<Data, Cache>;
 export const defaultData: Data = {
   displayCity: true,
   displayCountry: true,
+  maskIP: false,
 };


### PR DESCRIPTION
This is an option if the user only wants to see the location of the IP and does not want to display the full IP.