### PR TITLE
Used google's utility for grabbing favicon

### DIFF
--- a/src/plugins/widgets/links/Display.tsx
+++ b/src/plugins/widgets/links/Display.tsx
@@ -62,7 +62,7 @@ const Display: FC<Props> = ({ icon, name, number, url, linkOpenStyle }) => {
           <i>
             <img
               alt={domain}
-              src={`https://icons.duckduckgo.com/ip3/${domain}.ico`}
+              src={`https://www.google.com/s2/favicons?sz=32&domain_url=${domain}`}
             />
           </i>
         ) : null


### PR DESCRIPTION
The duckduckgo favicon grabber is not working for links with subdomains, resulting in broken icons. So I have used google's utility instead.

Eg:

https://icons.duckduckgo.com/ip3/https://music.youtube.com/

https://www.google.com/s2/favicons?sz=180&domain_url=https://music.youtube.com/

Fixes #619
