### PR TITLE
Add validation for response body && api key check

### DIFF
--- a/src/plugins/backgrounds/unsplash/api.ts
+++ b/src/plugins/backgrounds/unsplash/api.ts
@@ -20,6 +20,10 @@ export const fetchImages = async ({
     Authorization: `Client-ID ${UNSPLASH_API_KEY}`,
   });
 
+  if (!UNSPLASH_API_KEY) {
+    throw new Error("You must set the UNSPLASH_API_KEY environment variable.");
+  }
+
   params.set("count", "10");
 
   switch (by) {
@@ -45,17 +49,20 @@ export const fetchImages = async ({
   const res = await fetch(`${url}?${params}`, { headers, cache: "no-cache" });
   const body = await res.json();
 
-  // TODO: validate types
-
-  return body.map((item: any) => ({
-    src: item.urls.raw,
-    credit: {
-      imageLink: item.links.html,
-      location: item.location ? item.location.name : null,
-      userName: item.user.name,
-      userLink: item.user.links.html,
-    },
-  }));
+  if (Array.isArray(body)) {
+    return body.map((item: any) => ({
+      src: item.urls.raw,
+      credit: {
+        imageLink: item.links.html,
+        location: item.location ? item.location.name : null,
+        userName: item.user.name,
+        userLink: item.user.links.html,
+      },
+    }));
+  } else {
+    console.error('Expected an array, but received:', body);
+    return [];
+  }
 };
 
 /**


### PR DESCRIPTION
This PR addresses a critical issue with the GitHub contributions widget, which was found to be malfunctioning. The initial diagnosis led to the setup of a local development environment, during which it was discovered that the Unsplash API key was not configured. This oversight resulted in an unexpected response from the fetch request, subsequently triggering an error during the data mapping process due to the response body being of an unanticipated format.

The underlying issue has been identified as a missing Unsplash API key which, when not set, leads to a chain of uncaught exceptions culminating in an obscure error message. The necessary error handling has been implemented to ensure that such cases are handled gracefully in the future, prompting the developer to set the API key.

Additionally, this PR serves as an inquiry into the current status and future plans for the GitHub contribution calendar widget. We have noticed potential discrepancies in the API response from https://api.bloggify.net/gh-calendar/?username=7empestx, which might indicate changes in the API endpoint behavior or output. Clarification on this would be beneficial for further troubleshooting and subsequent rectification of the widget functionality.

Attached below is a visual representation of the widget issue for reference:

![image](https://github.com/joelshepherd/tabliss/assets/51809789/65f5e2f7-f468-45ea-99a1-d008d2f295e9)