### PR TITLE
Fix a typo in SearchSettings.tsx

### DIFF
--- a/src/plugins/widgets/search/SearchSettings.tsx
+++ b/src/plugins/widgets/search/SearchSettings.tsx
@@ -46,7 +46,7 @@ const SearchSettings: FC<Props> = ({ data = defaultData, setData }) => (
 
     {data.suggestionsEngine && (
       <label>
-        Suggestion Quanitity
+        Suggestion Quantity
         <input
           type="number"
           min="1"


### PR DESCRIPTION
Hey!
This is a PR that fixes a typo in SearchSettings.tsx - `Quanitity` should be `Quantity`.