### PR TITLE
Fix: Github map not displaing properly when username is entered

### DIFF
--- a/src/plugins/widgets/github/GitHub.tsx
+++ b/src/plugins/widgets/github/GitHub.tsx
@@ -10,7 +10,7 @@ import "./github-calendar.css";
 const GitHubCalendarWidget: FC<Props> = ({ data = defaultData, loader }) => {
   useEffect(() => {
     loader.push();
-    GitHubCalendar(".GitHubCalendar", data.username, {
+    GitHubCalendar(".calendar", data.username, {
       responsive: false,
       global_stats: data.showSummary,
     }).finally(() => {
@@ -23,7 +23,7 @@ const GitHubCalendarWidget: FC<Props> = ({ data = defaultData, loader }) => {
       <a
         href={"https://github.com/" + data.username}
         rel="noopener noreferrer"
-        className="GitHubCalendar"
+        className="calendar"
       />
     </div>
   );


### PR DESCRIPTION
Hi there, 
When GitHub username is entered , page doesn't show GitHub calendar however other details appeared .
![githubBug](https://github.com/user-attachments/assets/0402a947-5baf-4695-93e7-cd91b57c5bf3)

changing classname somehow fixed the issue , here's fixed scs.
![afterFix](https://github.com/user-attachments/assets/1a7a7051-f5e6-41b5-bb6c-8932be52f6cd)

please review/comment if needed.

suggestion:
We,can also achieve this with [_react-github-calender_](https://www.npmjs.com/package/react-github-calendar) with more flexibility on configuration & UI of calendar.
